### PR TITLE
DOCS: align CHANGELOG with SPRINT_PROD_READY_2026_01 (source of truth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ L'**AXE D — Prod Ready** est déclaré **TERMINÉ**.
 - ✅ **Baseline tests (Flutter / CI Linux)**
   - PASS : 482
   - FAIL : 0 (le run se termine par "All tests passed!")
+  - SKIP (opt-in DB + deprecated)
   - **Interprétation opposable** :
     - Tous les tests exécutés et déterministes sont verts (0 échec).
     - La condition CI verte est définie comme absence totale de tests en échec sur le périmètre exécuté.
@@ -42,7 +43,7 @@ L'**AXE D — Prod Ready** est déclaré **TERMINÉ**.
   - Isolation complète tests `route_permissions`
 - **Résultat** : ✅ Tous les tests passent en CI Linux, aucun test flaky
 
-##### **Tests LoginScreen — stabilisation (17/01/2025)**
+##### **Tests LoginScreen — stabilisation (17/01/2026)**
 Ajout d'attentes déterministes dans `login_screen_test.dart` (`pumpUntilFound` / `pumpUntilAnyFound`) afin de fiabiliser les tests sensibles au timing (SnackBar, messages de succès/erreur).  
 Validation locale confirmée :  
 `flutter test test/features/auth/screens/login_screen_test.dart -r expanded` → All tests passed.
@@ -79,6 +80,7 @@ Validation locale confirmée :
 - ✅ **Baseline tests (Flutter / CI Linux)**
   - PASS : 482
   - FAIL : 0 (le run se termine par "All tests passed!")
+  - SKIP (opt-in DB + deprecated)
   - **Interprétation opposable** :
     - Tous les tests exécutés et déterministes sont verts (0 échec).
     - La condition CI verte est définie comme absence totale de tests en échec sur le périmètre exécuté.
@@ -94,54 +96,6 @@ Validation locale confirmée :
 ---
 
 ## [Unreleased]
-
-### 🧪 **[Tests] — Fix Tests Fragiles (Réceptions + Sorties E2E) — 2026-01-15**
-
-#### **Problème**
-Après les correctifs web "écran blanc", deux tests fragiles échouaient :
-- **reception_list_screen_test.dart** : Crash `PaginatedDataTable` quand `rowsPerPage > rowCount` (assertion `availableRowsPerPage.contains(rowsPerPage) == false`)
-- **sorties_e2e_test.dart** : Dépendance à texte exact "Tableau de bord" (maintenant "Accueil") + crash `Supabase.instance` non initialisé dans `sortiesTableProvider`
-
-#### **Solution**
-
-##### **reception_list_screen_test.dart — Tests robustes**
-- **Helper `makeRows()`** : Génère datasets avec >= 10 lignes (évite crash `PaginatedDataTable` quand `rowsPerPage=10 > rowCount=1`)
-- **Layout déterministe** : Force desktop (`setSurfaceSize(1300, 800)`) pour tous les tests (évite variations mobile/desktop imprévisibles)
-- **Assertions structurelles** :
-  - Test "Source" : `find.byType(PaginatedDataTable)` + `find.textContaining('Source')` au lieu de texte exact
-  - Test fournisseur/partenaire : `find.byWidgetPredicate` pour `Icons.business` au lieu de texte exact "moccho tst" / "falcon test"
-  - Test placeholder : `find.byWidgetPredicate` pour `Icons.business_outlined` (déjà robuste)
-  - Vérifications supplémentaires : présence de champs sûrs ("Essence", "Citerne A", etc.)
-
-##### **sorties_e2e_test.dart — E2E robuste**
-- **Classe `_FakeSortieTableSource`** : Source de données mutable pour override `sortiesTableProvider` (évite `Supabase.instance` crash)
-- **Navigation directe** : `GoRouter.go('/sorties')` au lieu de `tap()` sur menu (évite hit-test fragile)
-- **Assertions structurelles** : `find.byType(DashboardShell)` au lieu de `find.textContaining('Tableau de bord')`
-- **Helper `pumpUntilFound()`** : Attend de manière déterministe qu'un widget existe (timeout 3s, step 50ms)
-- **Injection de données** : Après création de sortie, injection dans `fakeSortieTableSource` pour simuler le refresh de liste
-
-#### **Fichiers Modifiés**
-- `test/features/receptions/screens/reception_list_screen_test.dart` :
-  - Ajout helper `makeRows()` pour générer >= 10 lignes
-  - Force layout desktop pour tous les tests
-  - Remplacement assertions fragiles par assertions structurelles (icônes, types de widgets)
-- `test/features/sorties/sorties_e2e_test.dart` :
-  - Ajout classe `_FakeSortieTableSource` pour override `sortiesTableProvider`
-  - Navigation directe via `GoRouter` au lieu de `tap()` menu
-  - Remplacement assertion "Tableau de bord" par `find.byType(DashboardShell)`
-  - Injection de sortie créée dans fake source après soumission
-
-#### **Impact**
-- ✅ **Tests robustes** : Plus de dépendance à textes fragiles (locale/layout), assertions structurelles stables
-- ✅ **Pas de crash** : `PaginatedDataTable` fonctionne avec datasets >= 10 lignes, `sortiesTableProvider` override avec fake
-- ✅ **Layout déterministe** : Desktop forcé pour tests Réceptions (évite variations mobile/desktop)
-- ✅ **Zéro modification prod** : Tous les changements limités à `test/**`, PROD-LOCK respecté
-
-#### **Validation**
-- Commande validation : `flutter test test/features/sorties/sorties_e2e_test.dart test/features/receptions/screens/reception_list_screen_test.dart -r expanded`
-- Tests doivent passer sur CI (Linux) et local (Mac) sans timing flaky
-
----
 
 ### 📱 **[UI/UX] — Fix Mobile Logs/Audit (List Cards + Double Scroll) — 2026-01-15**
 

--- a/docs/SPRINT_PROD_READY_2026_01.md
+++ b/docs/SPRINT_PROD_READY_2026_01.md
@@ -97,12 +97,12 @@
 
 ---
 
-### 17/01/2025 — Tests LoginScreen stabilisés
+### 17/01/2026 — Tests LoginScreen stabilisés
 
-Les tests de l'écran de connexion utilisent désormais des attentes déterministes (`pumpUntilFound` / `pumpUntilAnyFound`) pour éliminer les flakiness liées au timing UI. Validation locale réussie sur l'ensemble du fichier `login_screen_test.dart`.
+Les tests de l'écran de connexion utilisent désormais des attentes déterministes (`pumpUntilFound` / `pumpUntilAnyFound`) afin d'éliminer les flakiness liées au timing UI (SnackBar, messages de succès/erreur).  
+Validation locale confirmée sur l'ensemble du fichier `login_screen_test.dart`.
 
 ---
-
 ## 🎯 Décisions Techniques Clés
 
 ### 1. Fake Repository Pattern


### PR DESCRIPTION
- AXE D closure report
- PROD READY status confirmation
- Sprint Prod Ready January 2026 documentation
- CHANGELOG update