### PR TITLE
feat(roles): PCA read-only, Directeur/Gérant restrictions + CDR mobile fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,83 @@ Validation locale confirmée :
 
 ## [Unreleased]
 
+### Permissions par rôle — Navigation & Actions (CDR / Réceptions / Sorties) (17/01/2026)
+
+#### ✅ PCA — Lecture seule (UI)
+Modules concernés : CDR, Réceptions, Sorties
+
+- Lecture seule sur Cours de Route (liste + détail)
+- Accès lecture Réceptions et Sorties
+- Aucun bouton de création, validation ou ajustement
+
+**Implémentation :**
+- CDR (détail) : Actions Modifier / Supprimer masquées  
+  Fichier : `lib/features/cours_route/screens/cours_route_detail_screen.dart`  
+  Test : `test/features/cours_route/screens/cdr_detail_screen_test.dart` (PCA)
+- Réceptions (liste) : Boutons "+", FAB, empty-state et colonne Actions masqués  
+  Fichier : `lib/features/receptions/screens/reception_list_screen.dart`  
+  Test : `test/features/receptions/screens/reception_list_screen_test.dart`
+- Sorties (liste) : Boutons "+", FAB, empty-state et colonne Actions masqués  
+  Fichier : `lib/features/sorties/screens/sortie_list_screen.dart`  
+  Test : `test/features/sorties/screens/sortie_list_screen_test.dart`
+
+#### ✅ Directeur — Accès complet hors ajustements
+- Accès complet navigation (CDR, Réceptions, Sorties, Stocks, KPI)
+- Création et validation Réceptions & Sorties
+- Ajustements de stock interdits (Admin uniquement)
+
+**Implémentation :**
+- Bouton "Corriger (Ajustement)" visible uniquement pour `UserRole.admin`
+- Réception (détail) : `lib/features/receptions/screens/reception_detail_screen.dart`  
+  Test : `test/features/receptions/screens/reception_detail_screen_test.dart` (Directeur)
+- Sortie (détail) : `lib/features/sorties/screens/sortie_detail_screen.dart`  
+  Test : `test/features/sorties/screens/sortie_detail_screen_test.dart` (Directeur)
+
+#### ✅ Gérant — Lecture seule CDR + Création Réceptions/Sorties
+- Lecture seule sur Cours de Route (comme PCA)
+- Création et validation Réceptions & Sorties
+- Ajustements de stock interdits (Admin uniquement)
+
+**Implémentation :**
+- CDR (liste) : Bouton "+" masqué pour Gérant  
+  Fichier : `lib/features/cours_route/screens/cours_route_list_screen.dart`  
+  Test : `test/features/cours_route/screens/cdr_list_screen_test.dart` (Gérant)
+- CDR (détail) : Actions Modifier / Supprimer masquées pour Gérant  
+  Fichier : `lib/features/cours_route/screens/cours_route_detail_screen.dart`  
+  Test : `test/features/cours_route/screens/cdr_detail_screen_test.dart` (Gérant)
+- Réception (détail) : Bouton "Corriger (Ajustement)" masqué (réservé Admin)  
+  Test : `test/features/receptions/screens/reception_detail_screen_test.dart` (Gérant)
+- Sortie (détail) : Bouton "Corriger (Ajustement)" masqué (réservé Admin)  
+  Test : `test/features/sorties/screens/sortie_detail_screen_test.dart` (Gérant)
+
+#### ✅ Admin — Accès total
+- Accès total : création, validation, ajustements, suppression
+- Aucun changement de comportement (non-régression)
+
+**Validation :**
+- Tests UI dédiés PCA / Directeur / Gérant passent
+- Aucune régression Admin détectée
+- Bouton "Corriger (Ajustement)" visible uniquement pour Admin (validé par tests)
+
+**Commandes de tests exécutées :**
+```bash
+flutter test test/features/cours_route/screens -r expanded
+flutter test test/features/receptions/screens/reception_detail_screen_test.dart -r expanded
+flutter test test/features/sorties/screens/sortie_detail_screen_test.dart -r expanded
+```
+
+### 📱 [UI/UX] — Fix Mobile CDR Detail "Progression du cours" (17/01/2026)
+
+- **Fix (Mobile)**: CDR Detail "Progression du cours" — suppression du RenderFlex overflow en rendant ModernStatusTimeline responsive (Wrap multi-lignes <600px, Row inchangé >=600px).  
+  Fichier: `lib/shared/ui/modern_components/modern_status_timeline.dart`
+
+**Commandes de tests exécutées :**
+```bash
+flutter test test/features/cours_route/screens -r expanded
+flutter test test/features/receptions/screens/reception_detail_screen_test.dart -r expanded
+flutter test test/features/sorties/screens/sortie_detail_screen_test.dart -r expanded
+```
+
 ### 🟡 STAGING — Exploitation prolongée (Validation métier & acceptation)
 
 - Activation du mode "STAGING prolongé (sécuritaire)"
@@ -107,8 +184,9 @@ Validation locale confirmée :
 **Phases de validation** :
 
 - ✅ PHASE 0 — Diagnostic CDR STAGING (VALIDÉ — Aucun correctif requis)
-- ⬜ PHASE 1 — Reset transactionnel total STAGING
-- ⬜ PHASE 2 — Simulation réaliste du dépôt (citernes & capacités)
+- ✅ PHASE 1 — STAGING propre (VALIDÉ — Reset transactionnel complet)
+- ✅ PHASE 2.2 — Validation CDR → Réception (STAGING) (VALIDÉ — Flux métier opérationnel)
+- ✅ PHASE 2 — Simulation réaliste du dépôt (citernes & capacités) (VALIDÉ — 17/01/2026)
 - ⬜ PHASE 3 — Validation navigation & permissions par rôle
   - ⬜ PCA — lecture seule globale
   - ⬜ Directeur / Gérant — usage réel
@@ -130,6 +208,64 @@ Validation locale confirmée :
 - **Décision** : Aucun correctif applicatif requis — comportement attendu conforme à la règle métier
 
 **Statut final** : ✅ **VALIDÉ** — Phase clôturée définitivement.
+
+---
+
+### ✅ Phase 1 — Reset transactionnel STAGING (Clôturée)
+
+- Purge complète des données transactionnelles STAGING :
+  - cours_de_route, receptions, sorties_produit, stocks_journaliers, log_actions
+- Correction "stock fantôme" post-reset : purge des sources de stock persistantes
+  - stocks_snapshot = 0
+  - stocks_adjustments = 0 (table INSERT-only, purge via TRUNCATE avec triggers désactivés temporairement)
+- Vérification : toutes les vues stock/KPI retournent 0 ligne
+  - v_stock_actuel, v_stock_actuel_snapshot, v_stocks_snapshot_corrige, v_kpi_stock_global, v_citerne_stock_snapshot_agg
+- Validation UI : plus aucun stock affiché après reset cache (web hard reload / android clear storage)
+
+---
+
+### ✅ Phase 2.2 — Validation CDR → Réception (STAGING)
+
+**Objectif** : Valider le flux réel d'exploitation CDR → Réception en environnement STAGING, avec impact stock et journalisation.
+
+**Actions réalisées** :
+- Création d'un CDR STAGING avec transition complète des statuts (CHARGEMENT → TRANSIT → FRONTIERE → ARRIVE)
+- Création d'une Réception liée au CDR avec affectation à une citerne existante
+- Calcul correct : Volume ambiant et Volume corrigé à 15°C
+- Génération automatique : Stock journalier, Snapshot stock, Logs métier
+
+**Vérifications DB (post-opération)** :
+- Tables métier : `receptions` → ✅ 1 ligne créée, `stocks_snapshot` → ✅ alimentée, `stocks_journaliers` → ✅ générés, `log_actions` → ✅ cohérents
+- Vues KPI : `v_stock_actuel` → ✅ cohérente, `v_stock_actuel_snapshot` → ✅ cohérente, `v_kpi_stock_global` → ✅ cohérente
+
+**Validation multi-plateforme** :
+- Android : ✅ Réception visible, données correctes, aucune erreur bloquante
+- Web (Chrome) : ⚠️ Erreur UI uniquement (PaginatedDataTable → rowsPerPage invalide), ❌ Aucun impact DB ou métier
+
+**Décision finale** : ✅ **Phase 2.2 officiellement CLÔTURÉE** — Le flux CDR → Réception → Stock → KPI → Logs est opérationnel. Le bug Web est hors périmètre de validation métier.
+
+---
+
+### ✅ Validation STAGING réaliste — 2026-01-17
+
+**Phase 2 — STAGING RÉALISTE officiellement clôturée**
+
+- Exécution complète du cycle métier réel (CDR → Réception → Stock → Sortie → KPI → Logs) en environnement STAGING
+- Validation des stocks, KPI et journalisation
+- Correction immédiate d'un bug Flutter Web (PaginatedDataTable / rowsPerPage)
+- Aucune dette technique ouverte
+- Validation multi-plateforme : Android ✅, Web (Chrome) ✅ après correctif
+
+---
+
+### ✅ Phase 2.2 — Validation UI Réceptions (Web)
+
+**Correction d'un crash Flutter Web lié à PaginatedDataTable**
+
+- **Cause** : `rowsPerPage` hors `availableRowsPerPage` après reset STAGING
+- **Impact** : UI Web uniquement (Android non concerné)
+- **Correctif** : Sécurisation de `rowsPerPage` pour garantir qu'il est toujours dans `availableRowsPerPage`
+- **Statut** : ✅ **VALIDÉ**
 
 ---
 

--- a/docs/PROD_READY_STATUS_2026_01_15.md
+++ b/docs/PROD_READY_STATUS_2026_01_15.md
@@ -17,11 +17,64 @@
 **Checklist officielle** :
 
 - ✅ CDR — OK (Phase 0 — Diagnostic CDR STAGING validé)
-- ⬜ STAGING PROPRE — OK
-- ⬜ STAGING RÉALISTE — OK
-- ⬜ PCA — ACCEPTE
-- ⬜ DIRECTEUR / GÉRANT — OK
+- ✅ STAGING PROPRE — OK (Phase 1 — Reset transactionnel STAGING + neutralisation stock fantôme validé)
+- ✅ CDR → RÉCEPTION — OK (Phase 2.2 — Validation flux métier STAGING validé)
+- ✅ STAGING RÉALISTE — OK (validé le 17/01/2026)
+- ✅ PCA — VALIDÉ (lecture seule UI sur CDR, Réceptions, Sorties validé par tests écran)
+- ✅ DIRECTEUR — VALIDÉ (ajustements Réception / Sortie réservés Admin — tests UI)
+- ✅ GÉRANT — VALIDÉ (lecture seule CDR + ajustements interdits — tests UI validés)
+- ✅ ADMIN — VALIDÉ (tous droits — aucune régression détectée)
 - ⬜ STAGING VALIDÉ
+
+### Validation Phase 1 — Reset transactionnel STAGING
+
+**Date de validation** : _[À compléter]_
+
+**Validation factuelle** :
+- ✅ DB transactionnelle : 0 ligne
+  - `cours_de_route` : 0 ligne
+  - `receptions` : 0 ligne
+  - `sorties_produit` : 0 ligne
+  - `stocks_journaliers` : 0 ligne
+  - `log_actions` : 0 ligne
+- ✅ Sources stock (stocks_snapshot, stocks_adjustments) : 0 ligne
+- ✅ Vues stock/KPI : 0 ligne
+  - v_stock_actuel, v_stock_actuel_snapshot, v_stocks_snapshot_corrige, v_kpi_stock_global, v_citerne_stock_snapshot_agg
+- ✅ UI : 0 (web + android)
+
+**Statut** : ✅ **VALIDÉ** / **BLOQUANT LE PASSAGE À PHASE 2**
+
+**Impact** : Environnement STAGING remis à zéro. Toute donnée postérieure est volontaire et traçable.
+
+### Validation Phase 2.2 — CDR → Réception (STAGING)
+
+**Date de validation** : _[À compléter]_
+
+**Validation factuelle** :
+- ✅ Flux métier validé : CDR → Réception → Stock → KPI → Logs opérationnel
+- ✅ Tables métier : `receptions` (1 ligne), `stocks_snapshot` (alimentée), `stocks_journaliers` (générés), `log_actions` (cohérents)
+- ✅ Vues KPI : `v_stock_actuel`, `v_stock_actuel_snapshot`, `v_kpi_stock_global` (cohérentes)
+- ✅ Android : Réception visible, données correctes, aucune erreur bloquante
+- ⚠️ Web (Chrome) : Erreur UI uniquement (PaginatedDataTable), aucun impact DB/métier
+
+**Statut** : ✅ **VALIDÉ** — Flux métier opérationnel. Bug Web classé UI/non bloquant.
+
+**Impact** : Validation du flux CDR → Réception confirmée. Aucun rollback requis.
+
+### Validation Phase 2 — STAGING RÉALISTE
+
+**Date** : 17/01/2026
+
+**Validation factuelle** :
+- ✅ Cycle métier complet exécuté en STAGING
+- ✅ Données réalistes (citernes, produits, volumes)
+- ✅ Aucune correction métier requise
+- ✅ Bug UI Web corrigé immédiatement
+- ✅ Aucune dette technique ouverte
+
+**Conclusion** :
+La phase STAGING RÉALISTE est officiellement validée.
+Le projet peut passer à la PHASE 3A — PCA (lecture seule & navigation).
 
 ### Règle de clôture
 Le projet sera déclaré **"PROD-READY FINAL"** uniquement lorsque toutes les cases ci-dessus
@@ -132,6 +185,22 @@ Les actions restantes (création du tag de release, merge final, déploiement) r
 - ✅ Redirections selon rôle (admin, directeur, gerant, operateur, pca, lecture)
 - ✅ Refresh manuel et auto-refresh après navigation
 
+#### Statut des rôles – Navigation & Actions
+
+| Rôle | CDR | Réceptions | Sorties | Ajustements |
+|------|-----|------------|---------|-------------|
+| **PCA** | ✅ Lecture | ✅ Lecture | ✅ Lecture | ❌ Aucun |
+| **Directeur** | ✅ | ✅ | ✅ | ✅ Admin-only (UI + tests) |
+| **Gérant** | ✅ Lecture | ✅ | ✅ | ✅ Admin-only (UI + tests) |
+| **Admin** | ✅ | ✅ | ✅ | ✅ |
+
+**Notes** :
+- Permissions alignées métier (PCA lecture seule, Directeur/Gérant création + validation, Admin ajustements)
+- Ajustements stock strictement Admin-only (validé par tests UI)
+- Navigation cohérente desktop / mobile (responsive)
+- Tests UI en place pour tous les rôles (PCA, Directeur, Gérant, Admin)
+- Restrictions implémentées au niveau UI et couvertes par des tests widget. Les règles DB/RLS seront traitées séparément si nécessaire.
+
 ---
 
 ## 3️⃣ État Git & Release
@@ -196,6 +265,7 @@ Les actions restantes (création du tag de release, merge final, déploiement) r
 ### UI Mobile
 - **Desktop/Tablet** : ✅ Fonctionnel
 - **Mobile** : ✅ Responsive et fonctionnel
+- **CDR Detail — Progression du cours (mobile)** : ✅ Overflow corrigé via ModernStatusTimeline responsive (<600px Wrap, >=600px Row)
 
 ---
 

--- a/docs/SPRINT_PROD_READY_2026_01.md
+++ b/docs/SPRINT_PROD_READY_2026_01.md
@@ -103,6 +103,128 @@ Les tests de l'écran de connexion utilisent désormais des attentes déterminis
 Validation locale confirmée sur l'ensemble du fichier `login_screen_test.dart`.
 
 ---
+
+### 17/01/2026 — UI Mobile — CDR Detail: timeline "Progression du cours" responsive
+
+**Problème** : Row horizontal déborde sur petits écrans (RenderFlex overflow)
+
+**Solution** : LayoutBuilder + breakpoint <600px
+- Mobile : Wrap (multi-lignes, sans lignes de connexion)
+- Desktop/Tablet : Row horizontal + lignes de connexion (inchangé)
+
+**Fichier** : `lib/shared/ui/modern_components/modern_status_timeline.dart` (lignes ~58-131)
+
+**Critères** : plus d'overflow, pas de scroll horizontal, desktop inchangé
+
+---
+
+### 17/01/2026 — 3A Permissions par rôle (PCA + Directeur)
+
+**PCA — lecture seule UI**
+Neutralisation complète des actions d'écriture sur :
+- CDR (détail)
+- Réceptions (liste)
+- Sorties (liste)
+Validé par tests UI dédiés
+
+**Directeur — restriction Ajustements**
+Ajustements Réception et Sortie accessibles uniquement à l'Admin
+Implémentation existante confirmée par tests UI
+Aucun impact sur les flux de création / validation
+
+**Tests exécutés**
+```bash
+flutter test test/features/receptions/screens/reception_detail_screen_test.dart -r expanded
+flutter test test/features/sorties/screens/sortie_detail_screen_test.dart -r expanded
+```
+
+**Résultat**
+- PCA : lecture seule effective sur tous les modules manipulables
+- Directeur : accès complet hors ajustements
+- Admin : comportement inchangé
+
+---
+
+### 17/01/2026 — 3B Permissions par rôle : Gérant
+
+**Gérant — lecture seule CDR + ajustements interdits**
+- CDR (liste) : bouton "+" masqué pour Gérant (même logique que PCA)
+- CDR (détail) : actions Modifier/Supprimer masquées pour Gérant
+- Réceptions/Sorties : ajustements interdits (bouton Admin-only déjà implémenté)
+
+**Implémentation**
+- Conditions PCA étendues à Gérant dans `cours_route_list_screen.dart` et `cours_route_detail_screen.dart`
+- Tests UI ajoutés pour valider le comportement Gérant (CDR list, CDR detail, Réception detail, Sortie detail)
+
+**Tests exécutés**
+```bash
+flutter test test/features/cours_route/screens -r expanded
+flutter test test/features/receptions/screens/reception_detail_screen_test.dart -r expanded
+flutter test test/features/sorties/screens/sortie_detail_screen_test.dart -r expanded
+```
+
+**Résultat**
+- Gérant : lecture seule sur CDR (comme PCA), création/validation Réceptions/Sorties autorisée, ajustements interdits (Admin uniquement)
+- Aucune régression détectée, tous les tests passent
+
+---
+
+### Phase 3 — Permissions par rôle (VALIDÉE — 17/01/2026)
+
+**Objectif** : Implémenter et valider les permissions par rôle (PCA, Directeur, Gérant, Admin) sur les modules CDR, Réceptions et Sorties.
+
+**Résumé des permissions :**
+
+| Rôle | CDR | Réceptions / Sorties | Ajustements | KPI / Dashboards |
+|------|-----|---------------------|-------------|------------------|
+| **PCA** | Lecture seule | Lecture seule | ❌ | Lecture |
+| **Directeur** | Lecture | Création + validation | ❌ (réservé Admin) | Accès complet |
+| **Gérant** | Lecture seule | Création + validation | ❌ (réservé Admin) | Accès complet |
+| **Admin** | Tous droits | Tous droits | ✅ (Admin uniquement) | Accès total |
+
+**Détails par rôle :**
+
+- **PCA**
+  - CDR : lecture seule (liste + détail)
+  - Réceptions / Sorties : lecture seule
+  - KPI / Dashboards : lecture
+  - Aucun bouton de création, validation ou ajustement
+
+- **Directeur**
+  - CDR : lecture
+  - Réceptions / Sorties : création + validation
+  - Ajustements : ❌ (réservé Admin)
+
+- **Gérant**
+  - CDR : lecture seule
+  - Réceptions / Sorties : création + validation
+  - Ajustements : ❌ (réservé Admin)
+
+- **Admin**
+  - Tous droits (référence métier)
+  - Création, validation, ajustements, suppression
+
+**Validation**
+- Tests UI dédiés PCA / Directeur / Gérant passent
+- Aucune régression Admin
+- Bouton "Corriger (Ajustement)" visible uniquement pour Admin (validé par tests)
+- Phase considérée TERMINÉE
+
+**Fichiers modifiés :**
+- `lib/features/cours_route/screens/cours_route_list_screen.dart`
+- `lib/features/cours_route/screens/cours_route_detail_screen.dart`
+- `lib/features/receptions/screens/reception_list_screen.dart`
+- `lib/features/receptions/screens/reception_detail_screen.dart`
+- `lib/features/sorties/screens/sortie_list_screen.dart`
+- `lib/features/sorties/screens/sortie_detail_screen.dart`
+
+**Tests ajoutés :**
+- `test/features/cours_route/screens/cdr_list_screen_test.dart` (Gérant)
+- `test/features/cours_route/screens/cdr_detail_screen_test.dart` (PCA, Gérant)
+- `test/features/receptions/screens/reception_detail_screen_test.dart` (Directeur, Gérant)
+- `test/features/sorties/screens/sortie_detail_screen_test.dart` (Directeur, Gérant)
+
+---
 ## 🎯 Décisions Techniques Clés
 
 ### 1. Fake Repository Pattern
@@ -222,13 +344,74 @@ une phase d'exploitation STAGING prolongée est engagée afin de :
 - Tester le système en conditions réelles par Directeur et Gérant
 - Sécuriser l'acceptation finale du projet
 
+## Gouvernance des rôles – Navigation & Actions UI
+
+### A. PCA — ✅ Implémenté et validé
+
+#### PCA (Président du Conseil d'Administration) — ✅ VALIDÉ
+
+**Portée**
+- Modules : Cours de Route (CDR), Réceptions, Sorties
+- Accès : Lecture seule (Read-only)
+
+**Comportement UI**
+- Aucun bouton de création visible
+- Aucune action de modification / suppression
+- Accès autorisé aux écrans de liste et de détail uniquement
+
+**Implémentation**
+- Guards UI basés sur `userRoleProvider`
+- Actions conditionnelles masquées selon le rôle
+
+**Tests**
+- Tests UI confirmant l'absence d'actions pour PCA :
+  - CDR
+  - Réceptions
+  - Sorties
+
+**Statut**
+- Conforme aux exigences métier
+- Considéré PROD-READY
+
+---
+
+### B. Directeur — 🟡 Règle métier validée (NON implémentée)
+
+#### Directeur — 🟡 RÈGLE MÉTIER VALIDÉE (À IMPLÉMENTER)
+
+**Règle métier**
+- Le rôle Directeur peut :
+  - Créer, consulter et valider des Réceptions
+  - Créer, consulter et valider des Sorties
+  - Consulter les CDR, Stocks et KPI
+- Le rôle Directeur **ne peut pas** :
+  - Effectuer des ajustements sur Réceptions
+  - Effectuer des ajustements sur Sorties
+  - (Ajustements réservés exclusivement au rôle Admin)
+
+**État d'implémentation**
+- Règle définie et validée fonctionnellement
+- ❌ Aucun guard UI encore appliqué
+- ❌ Boutons "Corriger (Ajustement)" encore visibles
+
+**Écrans concernés**
+- Détail Réception → bouton "Corriger (Ajustement)"
+- Détail Sortie → bouton "Corriger (Ajustement)"
+
+**Action à prévoir**
+- Ajouter un guard UI bloquant l'accès aux ajustements pour le rôle Directeur
+- Ajouter les tests UI associés
+
+⚠️ **Cette règle ne doit pas être considérée comme implémentée à ce stade.**
+
 ### Phases de validation (avec checklist)
 
 | PHASE | DESCRIPTION | STATUT | VALIDATION |
 |-------|-------------|--------|------------|
 | **PHASE 0** | Diagnostic CDR STAGING | ✅ | "CDR — OK" (VALIDÉ) |
-| **PHASE 1** | STAGING propre (reset transactionnel) | ⬜ | "STAGING PROPRE — OK" |
-| **PHASE 2** | Dépôt réaliste (citernes & capacités) | ⬜ | "STAGING RÉALISTE — OK" |
+| **PHASE 1** | STAGING propre (reset transactionnel) | ✅ | "STAGING PROPRE — OK" (VALIDÉ) |
+| **PHASE 2.2** | Validation CDR → Réception (STAGING) | ✅ | "CDR → RÉCEPTION — OK" (VALIDÉ) |
+| **PHASE 2** | Dépôt réaliste (citernes & capacités) | ✅ | "STAGING RÉALISTE — OK" (VALIDÉ) |
 | **PHASE 3A** | PCA — navigation & lecture seule | ⬜ | "PCA — ACCEPTE" |
 | **PHASE 3B** | Directeur / Gérant — usage réel | ⬜ | "DIRECTEUR / GÉRANT — OK" |
 | **PHASE 4** | Exploitation STAGING contrôlée | ⬜ | "STAGING VALIDÉ" |
@@ -249,6 +432,84 @@ une phase d'exploitation STAGING prolongée est engagée afin de :
 **Impact** : Clarification de la règle métier CDR. Risque résiduel : Aucun.
 
 **Préparation** : Phase 0 verrouillée définitivement. Passage en exploitation STAGING prolongée autorisé.
+
+## Phase 1 — Reset transactionnel STAGING (✅ CLÔTURÉ)
+
+### Objectif
+Repartir d'une base STAGING propre pour exploitation sécuritaire et tests réels (PCA / Directeur / Gérant).
+
+### Réalisé
+- Reset transactionnel : cours_de_route, receptions, sorties_produit, stocks_journaliers, log_actions (0 ligne partout).
+- Neutralisation des sources stock persistantes post-reset :
+  - stocks_snapshot = 0
+  - stocks_adjustments = 0 (purge contrôlée malgré politique INSERT-only)
+- Vues/KPI : 0 ligne sur v_stock_actuel et vues dérivées.
+- App : stock = 0 après purge cache (hard reload web / clear storage android).
+
+### Statut
+✅ Phase 1 verrouillée. Toute donnée STAGING ajoutée ensuite est volontaire et traçable.
+
+## Phase 2.2 — Validation CDR → Réception (STAGING) (✅ CLÔTURÉ)
+
+### Objectif
+Valider le flux réel d'exploitation CDR → Réception en environnement STAGING, avec impact stock et journalisation, sans dépendance UI.
+
+### Réalisé
+- Création d'un CDR STAGING avec transition complète des statuts (CHARGEMENT → TRANSIT → FRONTIERE → ARRIVE)
+- Création d'une Réception liée au CDR avec affectation à une citerne existante
+- Calcul correct : Volume ambiant et Volume corrigé à 15°C
+- Génération automatique : Stock journalier, Snapshot stock, Logs métier
+
+### Vérifications DB (post-opération)
+- Tables métier : `receptions` → ✅ 1 ligne créée, `stocks_snapshot` → ✅ alimentée, `stocks_journaliers` → ✅ générés, `log_actions` → ✅ cohérents
+- Vues KPI : `v_stock_actuel` → ✅ cohérente, `v_stock_actuel_snapshot` → ✅ cohérente, `v_kpi_stock_global` → ✅ cohérente
+
+### Validation multi-plateforme
+- Android : ✅ Réception visible, données correctes, aucune erreur bloquante
+- Web (Chrome) : ⚠️ Erreur UI uniquement (PaginatedDataTable → rowsPerPage invalide), ❌ Aucun impact DB ou métier
+
+### Analyse de l'erreur Web
+- **Origine** : PaginatedDataTable
+- **Cause** : `rowsPerPage` non présent dans `availableRowsPerPage`
+- **Impact** : Affichage seulement, aucune donnée corrompue, flux métier intact
+- **Correctif** : Sécurisation de `rowsPerPage` (correction planifiée hors Phase 2.2)
+
+### Statut
+✅ Phase 2.2 officiellement CLÔTURÉE. Le flux CDR → Réception → Stock → KPI → Logs est opérationnel. Le bug Web est hors périmètre de validation métier. Aucun rollback requis.
+
+## Phase 2 — STAGING RÉALISTE (✅ CLÔTURÉE)
+
+### Date de validation
+17/01/2026
+
+### Objectif de la phase
+Valider l'application ML_PP MVP en conditions STAGING réalistes, avec données métier cohérentes, via l'exécution complète d'un cycle réel sans modification de code.
+
+### Scénario exécuté
+- Création d'un Cours de Route (CHARGEMENT → TRANSIT → FRONTIERE → ARRIVE)
+- Création d'une Réception liée au CDR
+- Génération automatique des stocks et logs
+- Vérification des stocks post-réception
+- Création d'une Sortie produit
+- Vérification des KPI et de la journalisation
+
+### Résultats factuels
+- Flux métier complet exécuté sans erreur bloquante
+- Stock MONALUXE correctement incrémenté puis décrémenté
+- KPI cohérents avec les opérations réalisées
+- Logs RECEPTION_CREEE et SORTIE_CREEE présents et corrects
+- Validation multi-plateforme :
+  - Android : affichage correct
+  - Web (Chrome) : bug UI identifié et corrigé immédiatement
+
+### Incident rencontré
+**Bug Flutter Web (PaginatedDataTable)** :
+- **Cause** : `rowsPerPage` non présent dans `availableRowsPerPage`
+- **Impact** : UI uniquement
+- **Action** : correctif appliqué immédiatement (aucune dette technique)
+
+### Statut
+✅ **PHASE 2 — STAGING RÉALISTE VALIDÉE**
 
 ### Règles de validation
 

--- a/lib/features/cours_route/screens/cours_route_detail_screen.dart
+++ b/lib/features/cours_route/screens/cours_route_detail_screen.dart
@@ -286,21 +286,22 @@ class CoursRouteDetailScreen extends ConsumerWidget {
                               ],
                             ),
                             const SizedBox(height: 16),
-                            // Actions principales
-                            ModernActionCard(
-                              title: 'Actions',
-                              subtitle: c.statut == StatutCours.decharge
-                                  ? 'Cours déchargé - Actions limitées'
-                                  : 'Modifier ou supprimer le cours',
-                              icon: Icons.settings,
-                              accentColor: Colors.orange,
-                              actions: _buildActionButtons(
-                                context,
-                                ref,
-                                c,
-                                userRole,
+                            // Actions principales (masquée pour PCA)
+                            if (!(userRole == UserRole.pca))
+                              ModernActionCard(
+                                title: 'Actions',
+                                subtitle: c.statut == StatutCours.decharge
+                                    ? 'Cours déchargé - Actions limitées'
+                                    : 'Modifier ou supprimer le cours',
+                                icon: Icons.settings,
+                                accentColor: Colors.orange,
+                                actions: _buildActionButtons(
+                                  context,
+                                  ref,
+                                  c,
+                                  userRole,
+                                ),
                               ),
-                            ),
                             // Message informatif pour les cours déchargés
                             if (c.statut == StatutCours.decharge &&
                                 userRole?.isAdmin != true)
@@ -427,22 +428,23 @@ class CoursRouteDetailScreen extends ConsumerWidget {
                           Row(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              Expanded(
-                                child: ModernActionCard(
-                                  title: 'Actions',
-                                  subtitle: c.statut == StatutCours.decharge
-                                      ? 'Cours déchargé - Actions limitées'
-                                      : 'Modifier ou supprimer le cours',
-                                  icon: Icons.settings,
-                                  accentColor: Colors.orange,
-                                  actions: _buildActionButtons(
-                                    context,
-                                    ref,
-                                    c,
-                                    userRole,
+                              if (!(userRole == UserRole.pca))
+                                Expanded(
+                                  child: ModernActionCard(
+                                    title: 'Actions',
+                                    subtitle: c.statut == StatutCours.decharge
+                                        ? 'Cours déchargé - Actions limitées'
+                                        : 'Modifier ou supprimer le cours',
+                                    icon: Icons.settings,
+                                    accentColor: Colors.orange,
+                                    actions: _buildActionButtons(
+                                      context,
+                                      ref,
+                                      c,
+                                      userRole,
+                                    ),
                                   ),
                                 ),
-                              ),
                               if ((c.note ?? '').trim().isNotEmpty) ...[
                                 const SizedBox(width: 16),
                                 Expanded(
@@ -703,6 +705,7 @@ class CoursRouteDetailScreen extends ConsumerWidget {
 
     final actions = <ModernActionButton>[];
 
+    // Ne pas ajouter le bouton "Modifier" si l'utilisateur ne peut pas modifier
     if (canEdit) {
       actions.add(
         ModernActionButton(
@@ -712,18 +715,9 @@ class CoursRouteDetailScreen extends ConsumerWidget {
           onPressed: () => context.push('/cours/${cours.id}/edit'),
         ),
       );
-    } else {
-      // Bouton désactivé
-      actions.add(
-        ModernActionButton(
-          label: 'Modifier',
-          icon: Icons.edit,
-          accentColor: Colors.grey,
-          onPressed: null,
-        ),
-      );
     }
 
+    // Ne pas ajouter le bouton "Supprimer" si l'utilisateur ne peut pas supprimer
     if (canDelete) {
       actions.add(
         ModernActionButton(
@@ -731,16 +725,6 @@ class CoursRouteDetailScreen extends ConsumerWidget {
           icon: Icons.delete,
           isDanger: true,
           onPressed: () => _confirmDelete(context, ref, cours.id),
-        ),
-      );
-    } else {
-      // Bouton désactivé
-      actions.add(
-        ModernActionButton(
-          label: 'Supprimer',
-          icon: Icons.delete,
-          isDanger: true,
-          onPressed: null,
         ),
       );
     }
@@ -757,6 +741,12 @@ class CoursRouteDetailScreen extends ConsumerWidget {
       '🔍 _canEditCours: statut=${cours.statut.name}, userRole=$userRole, effectiveRole=$effectiveRole, isAdmin=${effectiveRole.isAdmin}',
     );
 
+    // PCA : lecture seule, jamais de modification
+    if (effectiveRole == UserRole.pca) {
+      debugPrint('🔍 _canEditCours: rôle PCA, canEdit=false');
+      return false;
+    }
+
     // Si le cours est déchargé, seul un admin peut le modifier
     if (cours.statut == StatutCours.decharge) {
       final canEdit = effectiveRole.isAdmin;
@@ -764,7 +754,7 @@ class CoursRouteDetailScreen extends ConsumerWidget {
       return canEdit;
     }
 
-    // Pour les autres statuts, tous les utilisateurs authentifiés peuvent modifier
+    // Pour les autres statuts, tous les utilisateurs authentifiés (sauf PCA) peuvent modifier
     final canEdit = userRole != null;
     debugPrint('🔍 _canEditCours: cours non déchargé, canEdit=$canEdit');
     return canEdit;
@@ -779,6 +769,12 @@ class CoursRouteDetailScreen extends ConsumerWidget {
       '🔍 _canDeleteCours: statut=${cours.statut.name}, userRole=$userRole, effectiveRole=$effectiveRole, isAdmin=${effectiveRole.isAdmin}',
     );
 
+    // PCA : lecture seule, jamais de suppression
+    if (effectiveRole == UserRole.pca) {
+      debugPrint('🔍 _canDeleteCours: rôle PCA, canDelete=false');
+      return false;
+    }
+
     // Si le cours est déchargé, seul un admin peut le supprimer
     if (cours.statut == StatutCours.decharge) {
       final canDelete = effectiveRole.isAdmin;
@@ -786,7 +782,7 @@ class CoursRouteDetailScreen extends ConsumerWidget {
       return canDelete;
     }
 
-    // Pour les autres statuts, tous les utilisateurs authentifiés peuvent supprimer
+    // Pour les autres statuts, tous les utilisateurs authentifiés (sauf PCA) peuvent supprimer
     final canDelete = userRole != null;
     debugPrint('🔍 _canDeleteCours: cours non déchargé, canDelete=$canDelete');
     return canDelete;

--- a/lib/features/cours_route/screens/cours_route_detail_screen.dart
+++ b/lib/features/cours_route/screens/cours_route_detail_screen.dart
@@ -286,8 +286,8 @@ class CoursRouteDetailScreen extends ConsumerWidget {
                               ],
                             ),
                             const SizedBox(height: 16),
-                            // Actions principales (masquée pour PCA)
-                            if (!(userRole == UserRole.pca))
+                            // Actions principales (masquée pour PCA/Gérant)
+                            if (!(userRole == UserRole.pca || userRole == UserRole.gerant))
                               ModernActionCard(
                                 title: 'Actions',
                                 subtitle: c.statut == StatutCours.decharge
@@ -428,7 +428,7 @@ class CoursRouteDetailScreen extends ConsumerWidget {
                           Row(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              if (!(userRole == UserRole.pca))
+                              if (!(userRole == UserRole.pca || userRole == UserRole.gerant))
                                 Expanded(
                                   child: ModernActionCard(
                                     title: 'Actions',
@@ -741,9 +741,9 @@ class CoursRouteDetailScreen extends ConsumerWidget {
       '🔍 _canEditCours: statut=${cours.statut.name}, userRole=$userRole, effectiveRole=$effectiveRole, isAdmin=${effectiveRole.isAdmin}',
     );
 
-    // PCA : lecture seule, jamais de modification
-    if (effectiveRole == UserRole.pca) {
-      debugPrint('🔍 _canEditCours: rôle PCA, canEdit=false');
+    // PCA/Gérant : lecture seule, jamais de modification
+    if (effectiveRole == UserRole.pca || effectiveRole == UserRole.gerant) {
+      debugPrint('🔍 _canEditCours: rôle PCA/Gérant, canEdit=false');
       return false;
     }
 
@@ -769,9 +769,9 @@ class CoursRouteDetailScreen extends ConsumerWidget {
       '🔍 _canDeleteCours: statut=${cours.statut.name}, userRole=$userRole, effectiveRole=$effectiveRole, isAdmin=${effectiveRole.isAdmin}',
     );
 
-    // PCA : lecture seule, jamais de suppression
-    if (effectiveRole == UserRole.pca) {
-      debugPrint('🔍 _canDeleteCours: rôle PCA, canDelete=false');
+    // PCA/Gérant : lecture seule, jamais de suppression
+    if (effectiveRole == UserRole.pca || effectiveRole == UserRole.gerant) {
+      debugPrint('🔍 _canDeleteCours: rôle PCA/Gérant, canDelete=false');
       return false;
     }
 

--- a/lib/features/cours_route/widgets/infinite_scroll_list.dart
+++ b/lib/features/cours_route/widgets/infinite_scroll_list.dart
@@ -18,8 +18,8 @@ class InfiniteScrollCoursList extends ConsumerStatefulWidget {
     required this.produitCodes,
     required this.depots,
     required this.onCoursTap,
-    required this.onAdvanceStatus,
-    required this.onCreateReception,
+    this.onAdvanceStatus,
+    this.onCreateReception,
   });
 
   final Map<String, String> fournisseurs;
@@ -27,8 +27,8 @@ class InfiniteScrollCoursList extends ConsumerStatefulWidget {
   final Map<String, String> produitCodes;
   final Map<String, String> depots;
   final void Function(CoursDeRoute) onCoursTap;
-  final void Function(CoursDeRoute) onAdvanceStatus;
-  final void Function(CoursDeRoute) onCreateReception;
+  final void Function(CoursDeRoute)? onAdvanceStatus;
+  final void Function(CoursDeRoute)? onCreateReception;
 
   @override
   ConsumerState<InfiniteScrollCoursList> createState() =>
@@ -103,8 +103,8 @@ class _InfiniteScrollCoursListState
           produitCodes: widget.produitCodes,
           depots: widget.depots,
           onTap: () => widget.onCoursTap(c),
-          onAdvanceStatus: () => widget.onAdvanceStatus(c),
-          onCreateReception: () => widget.onCreateReception(c),
+          onAdvanceStatus: widget.onAdvanceStatus == null ? null : () => widget.onAdvanceStatus!(c),
+          onCreateReception: widget.onCreateReception == null ? null : () => widget.onCreateReception!(c),
         );
       },
     );
@@ -120,8 +120,8 @@ class _CoursCard extends StatelessWidget {
     required this.produitCodes,
     required this.depots,
     required this.onTap,
-    required this.onAdvanceStatus,
-    required this.onCreateReception,
+    this.onAdvanceStatus,
+    this.onCreateReception,
   });
 
   final CoursDeRoute cours;
@@ -130,8 +130,8 @@ class _CoursCard extends StatelessWidget {
   final Map<String, String> produitCodes;
   final Map<String, String> depots;
   final VoidCallback onTap;
-  final VoidCallback onAdvanceStatus;
-  final VoidCallback onCreateReception;
+  final VoidCallback? onAdvanceStatus;
+  final VoidCallback? onCreateReception;
 
   @override
   Widget build(BuildContext context) {
@@ -199,16 +199,21 @@ class _CoursCard extends StatelessWidget {
 class _ActionButtons extends ConsumerWidget {
   const _ActionButtons({
     required this.cours,
-    required this.onAdvanceStatus,
-    required this.onCreateReception,
+    this.onAdvanceStatus,
+    this.onCreateReception,
   });
 
   final CoursDeRoute cours;
-  final VoidCallback onAdvanceStatus;
-  final VoidCallback onCreateReception;
+  final VoidCallback? onAdvanceStatus;
+  final VoidCallback? onCreateReception;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Si aucun callback n'est disponible (PCA), ne rien afficher
+    if (onAdvanceStatus == null && onCreateReception == null) {
+      return const SizedBox.shrink();
+    }
+
     final nextStatut = StatutCoursDb.next(cours.statut);
 
     if (nextStatut == null) {
@@ -216,6 +221,7 @@ class _ActionButtons extends ConsumerWidget {
     }
 
     if (nextStatut == StatutCours.decharge) {
+      if (onCreateReception == null) return const SizedBox.shrink();
       return FilledButton.tonalIcon(
         onPressed: onCreateReception,
         icon: const Icon(Icons.add_box, size: 16),
@@ -227,6 +233,7 @@ class _ActionButtons extends ConsumerWidget {
       );
     }
 
+    if (onAdvanceStatus == null) return const SizedBox.shrink();
     return FilledButton.tonalIcon(
       onPressed: onAdvanceStatus,
       icon: const Icon(Icons.trending_flat, size: 16),

--- a/test/features/cours_route/screens/cdr_detail_screen_test.dart
+++ b/test/features/cours_route/screens/cdr_detail_screen_test.dart
@@ -413,5 +413,61 @@ void main() {
         reason: 'L\'écran de détail doit être affiché même pour PCA',
       );
     });
+
+    testWidgets('CDR Detail (Gérant) n\'affiche pas les actions Modifier/Supprimer', (
+      tester,
+    ) async {
+      // Arrange
+      final cdrTransit = createTestCdrDetail(
+        id: 'cdr-gerant-test',
+        statut: StatutCours.transit,
+      );
+      final fakeService = FakeCoursDeRouteServiceForDetail(cours: cdrTransit);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            coursDeRouteServiceProvider.overrideWithValue(fakeService),
+            coursDeRouteByIdProvider(
+              cdrTransit.id,
+            ).overrideWith((ref) async => cdrTransit),
+            userRoleProvider.overrideWith((ref) => UserRole.gerant),
+            refDataProvider.overrideWith((ref) async => createFakeRefData()),
+          ],
+          child: MaterialApp(
+            home: CoursRouteDetailScreen(coursId: cdrTransit.id),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Assert: Les boutons "Modifier" et "Supprimer" ne doivent pas être visibles
+      expect(
+        find.text('Modifier'),
+        findsNothing,
+        reason: 'Le bouton "Modifier" ne doit pas être affiché pour le rôle Gérant',
+      );
+
+      expect(
+        find.text('Supprimer'),
+        findsNothing,
+        reason: 'Le bouton "Supprimer" ne doit pas être affiché pour le rôle Gérant',
+      );
+
+      // Vérifier que la card "Actions" n'est pas affichée pour Gérant
+      expect(
+        find.text('Actions'),
+        findsNothing,
+        reason: 'La card "Actions" ne doit pas être affichée pour le rôle Gérant',
+      );
+
+      // Vérifier que l'écran se charge correctement malgré tout
+      expect(
+        find.byType(CoursRouteDetailScreen),
+        findsOneWidget,
+        reason: 'L\'écran de détail doit être affiché même pour Gérant',
+      );
+    });
   });
 }

--- a/test/features/cours_route/screens/cdr_detail_screen_test.dart
+++ b/test/features/cours_route/screens/cdr_detail_screen_test.dart
@@ -355,4 +355,63 @@ void main() {
       );
     });
   });
+
+  group('CDR Detail Screen - PCA Read-Only', () {
+    testWidgets('CDR Detail (PCA) n\'affiche pas les actions Modifier/Supprimer', (
+      tester,
+    ) async {
+      // Arrange
+      final cdrTransit = createTestCdrDetail(
+        id: 'cdr-pca-test',
+        statut: StatutCours.transit,
+      );
+      final fakeService = FakeCoursDeRouteServiceForDetail(cours: cdrTransit);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            coursDeRouteServiceProvider.overrideWithValue(fakeService),
+            coursDeRouteByIdProvider(
+              cdrTransit.id,
+            ).overrideWith((ref) async => cdrTransit),
+            userRoleProvider.overrideWith((ref) => UserRole.pca),
+            refDataProvider.overrideWith((ref) async => createFakeRefData()),
+          ],
+          child: MaterialApp(
+            home: CoursRouteDetailScreen(coursId: cdrTransit.id),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Assert: Les boutons "Modifier" et "Supprimer" ne doivent pas être visibles
+      expect(
+        find.text('Modifier'),
+        findsNothing,
+        reason: 'Le bouton "Modifier" ne doit pas être affiché pour le rôle PCA',
+      );
+
+      expect(
+        find.text('Supprimer'),
+        findsNothing,
+        reason: 'Le bouton "Supprimer" ne doit pas être affiché pour le rôle PCA',
+      );
+
+      // Vérifier que la card "Actions" n'est pas affichée pour PCA
+      // (puisque nous la masquons complètement)
+      expect(
+        find.text('Actions'),
+        findsNothing,
+        reason: 'La card "Actions" ne doit pas être affichée pour le rôle PCA',
+      );
+
+      // Vérifier que l'écran se charge correctement malgré tout
+      expect(
+        find.byType(CoursRouteDetailScreen),
+        findsOneWidget,
+        reason: 'L\'écran de détail doit être affiché même pour PCA',
+      );
+    });
+  });
 }

--- a/test/features/cours_route/screens/cdr_list_screen_test.dart
+++ b/test/features/cours_route/screens/cdr_list_screen_test.dart
@@ -463,5 +463,47 @@ void main() {
             'next(DECHARGE) doit retourner null, donc le bouton doit être désactivé',
       );
     });
+
+    testWidgets(
+      'CDR List (Gérant) n\'affiche pas le bouton Créer',
+      (tester) async {
+        // Arrange
+        final cdrTest = createTestCdr(
+          id: 'cdr-gerant-test',
+          statut: StatutCours.chargement,
+        );
+        final fakeService = FakeCoursDeRouteServiceForWidgets(
+          seedData: [cdrTest],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              coursDeRouteServiceProvider.overrideWithValue(fakeService),
+              coursDeRouteListProvider.overrideWith((ref) async => [cdrTest]),
+              userRoleProvider.overrideWith((ref) => UserRole.gerant),
+              refDataProvider.overrideWith((ref) async => createFakeRefData()),
+            ],
+            child: const MaterialApp(home: CoursRouteListScreen()),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Assert - Vérifier que le bouton "+" n'est pas présent
+        expect(
+          find.byIcon(Icons.add),
+          findsNothing,
+          reason: 'Le bouton "+" ne doit pas être affiché pour le rôle Gérant',
+        );
+
+        // Vérifier que l'écran se charge correctement malgré tout
+        expect(
+          find.byType(CoursRouteListScreen),
+          findsOneWidget,
+          reason: 'L\'écran de liste doit être affiché même pour Gérant',
+        );
+      },
+    );
   });
 }

--- a/test/features/dashboard/screens/dashboard_screens_smoke_test.dart
+++ b/test/features/dashboard/screens/dashboard_screens_smoke_test.dart
@@ -23,6 +23,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart' as Riverpod;
 import 'package:ml_pp_mvp/features/profil/providers/profil_provider.dart'
     show CurrentProfilNotifier;
 import 'package:ml_pp_mvp/features/dashboard/providers/citernes_sous_seuil_provider.dart';
+import 'package:ml_pp_mvp/data/repositories/stocks_kpi_repository.dart';
+import 'package:ml_pp_mvp/features/stocks/data/stocks_kpi_providers.dart';
 
 /// Fake notifier pour currentProfilProvider dans les tests
 class _FakeProfilNotifier extends CurrentProfilNotifier {
@@ -31,6 +33,111 @@ class _FakeProfilNotifier extends CurrentProfilNotifier {
 
   @override
   Future<Profil?> build() async => _profil;
+}
+
+/// Fake repository minimal pour éviter Supabase.instance dans les tests smoke
+class _FakeStocksKpiRepositoryForSmokeTests implements StocksKpiRepository {
+  @override
+  Future<List<DepotGlobalStockKpi>> fetchDepotProductTotals({
+    String? depotId,
+    String? produitId,
+    DateTime? dateJour,
+  }) async {
+    return [
+      const DepotGlobalStockKpi(
+        depotId: 'test-depot',
+        depotNom: 'Test Dépôt',
+        produitId: 'produit-1',
+        produitNom: 'Essence',
+        stockAmbiantTotal: 10000.0,
+        stock15cTotal: 9500.0,
+      ),
+    ];
+  }
+
+  @override
+  Future<List<DepotOwnerStockKpi>> fetchDepotOwnerTotals({
+    String? depotId,
+    String? produitId,
+    String? proprietaireType,
+    DateTime? dateJour,
+  }) async {
+    // Retourner 2 owners (MONALUXE et PARTENAIRE) pour que l'UI fonctionne
+    return [
+      const DepotOwnerStockKpi(
+        depotId: 'test-depot',
+        depotNom: 'Test Dépôt',
+        proprietaireType: 'MONALUXE',
+        produitId: 'produit-1',
+        produitNom: 'Essence',
+        stockAmbiantTotal: 6000.0,
+        stock15cTotal: 5700.0,
+      ),
+      const DepotOwnerStockKpi(
+        depotId: 'test-depot',
+        depotNom: 'Test Dépôt',
+        proprietaireType: 'PARTENAIRE',
+        produitId: 'produit-1',
+        produitNom: 'Essence',
+        stockAmbiantTotal: 4000.0,
+        stock15cTotal: 3800.0,
+      ),
+    ];
+  }
+
+  @override
+  Future<List<CiterneOwnerStockSnapshot>> fetchCiterneOwnerSnapshots({
+    String? depotId,
+    String? citerneId,
+    String? produitId,
+    String? proprietaireType,
+    DateTime? dateJour,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<List<CiterneGlobalStockSnapshot>> fetchCiterneGlobalSnapshots({
+    String? depotId,
+    String? citerneId,
+    String? produitId,
+    DateTime? dateJour,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<double> fetchDepotTotalCapacity({
+    required String depotId,
+    String? produitId,
+  }) async {
+    return 20000.0;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchCiterneStocksFromSnapshot({
+    String? depotId,
+    String? citerneId,
+    String? produitId,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchDepotOwnerStocksFromSnapshot({
+    required String depotId,
+    String? produitId,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchStockActuelRows({
+    required String depotId,
+    String? produitId,
+  }) async {
+    return [];
+  }
 }
 
 /// Helper pour créer un MaterialApp.router avec GoRouter minimal pour les tests
@@ -114,6 +221,10 @@ void main() {
           kpiProviderProvider.overrideWith((ref) async => kpiSnapshot),
           // Override citernes sous seuil provider
           citernesSousSeuilProvider.overrideWith((ref) async => []),
+          // Override stocksKpiRepositoryProvider pour éviter Supabase.instance
+          stocksKpiRepositoryProvider.overrideWith(
+            (ref) => _FakeStocksKpiRepositoryForSmokeTests(),
+          ),
         ],
       );
     }

--- a/test/features/dashboard/widgets/role_dashboard_test.dart
+++ b/test/features/dashboard/widgets/role_dashboard_test.dart
@@ -14,6 +14,113 @@ import 'package:ml_pp_mvp/features/kpi/models/kpi_models.dart';
 import 'package:ml_pp_mvp/features/profil/providers/profil_provider.dart';
 import 'package:ml_pp_mvp/core/models/profil.dart';
 import 'package:ml_pp_mvp/features/dashboard/providers/citernes_sous_seuil_provider.dart';
+import 'package:ml_pp_mvp/data/repositories/stocks_kpi_repository.dart';
+import 'package:ml_pp_mvp/features/stocks/data/stocks_kpi_providers.dart';
+
+/// Fake repository minimal pour éviter Supabase.instance dans les tests
+class _FakeStocksKpiRepositoryForTests implements StocksKpiRepository {
+  @override
+  Future<List<DepotGlobalStockKpi>> fetchDepotProductTotals({
+    String? depotId,
+    String? produitId,
+    DateTime? dateJour,
+  }) async {
+    return [
+      const DepotGlobalStockKpi(
+        depotId: 'test-depot',
+        depotNom: 'Test Dépôt',
+        produitId: 'produit-1',
+        produitNom: 'Essence',
+        stockAmbiantTotal: 10000.0,
+        stock15cTotal: 9500.0,
+      ),
+    ];
+  }
+
+  @override
+  Future<List<DepotOwnerStockKpi>> fetchDepotOwnerTotals({
+    String? depotId,
+    String? produitId,
+    String? proprietaireType,
+    DateTime? dateJour,
+  }) async {
+    // Retourner 2 owners (MONALUXE et PARTENAIRE) pour que l'UI fonctionne
+    return [
+      const DepotOwnerStockKpi(
+        depotId: 'test-depot',
+        depotNom: 'Test Dépôt',
+        proprietaireType: 'MONALUXE',
+        produitId: 'produit-1',
+        produitNom: 'Essence',
+        stockAmbiantTotal: 6000.0,
+        stock15cTotal: 5700.0,
+      ),
+      const DepotOwnerStockKpi(
+        depotId: 'test-depot',
+        depotNom: 'Test Dépôt',
+        proprietaireType: 'PARTENAIRE',
+        produitId: 'produit-1',
+        produitNom: 'Essence',
+        stockAmbiantTotal: 4000.0,
+        stock15cTotal: 3800.0,
+      ),
+    ];
+  }
+
+  @override
+  Future<List<CiterneOwnerStockSnapshot>> fetchCiterneOwnerSnapshots({
+    String? depotId,
+    String? citerneId,
+    String? produitId,
+    String? proprietaireType,
+    DateTime? dateJour,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<List<CiterneGlobalStockSnapshot>> fetchCiterneGlobalSnapshots({
+    String? depotId,
+    String? citerneId,
+    String? produitId,
+    DateTime? dateJour,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<double> fetchDepotTotalCapacity({
+    required String depotId,
+    String? produitId,
+  }) async {
+    return 20000.0;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchCiterneStocksFromSnapshot({
+    String? depotId,
+    String? citerneId,
+    String? produitId,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchDepotOwnerStocksFromSnapshot({
+    required String depotId,
+    String? produitId,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchStockActuelRows({
+    required String depotId,
+    String? produitId,
+  }) async {
+    return [];
+  }
+}
 
 /// Helper pour créer un MaterialApp.router avec GoRouter minimal pour les tests
 Widget _appWithRouter(Widget child, {String initialLocation = "/"}) {
@@ -42,6 +149,9 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           kpiProviderProvider.overrideWith((ref) => completer.future),
+          stocksKpiRepositoryProvider.overrideWith(
+            (ref) => _FakeStocksKpiRepositoryForTests(),
+          ),
         ],
       );
 
@@ -81,6 +191,9 @@ void main() {
           kpiProviderProvider.overrideWith(
             (ref) =>
                 Future<KpiSnapshot>.error('Test error', StackTrace.current),
+          ),
+          stocksKpiRepositoryProvider.overrideWith(
+            (ref) => _FakeStocksKpiRepositoryForTests(),
           ),
         ],
       );
@@ -143,6 +256,9 @@ void main() {
           citernesSousSeuilProvider.overrideWith(
             (ref) async => [],
           ), // Pas d'alertes pour ce test
+          stocksKpiRepositoryProvider.overrideWith(
+            (ref) => _FakeStocksKpiRepositoryForTests(),
+          ),
         ],
       );
 
@@ -217,6 +333,9 @@ void main() {
           citernesSousSeuilProvider.overrideWith(
             (ref) async => [],
           ), // Pas d'alertes pour ce test
+          stocksKpiRepositoryProvider.overrideWith(
+            (ref) => _FakeStocksKpiRepositoryForTests(),
+          ),
         ],
       );
 
@@ -282,6 +401,9 @@ void main() {
           citernesSousSeuilProvider.overrideWith(
             (ref) async => [],
           ), // Pas d'alertes pour ce test
+          stocksKpiRepositoryProvider.overrideWith(
+            (ref) => _FakeStocksKpiRepositoryForTests(),
+          ),
         ],
       );
 

--- a/test/features/receptions/screens/reception_detail_screen_test.dart
+++ b/test/features/receptions/screens/reception_detail_screen_test.dart
@@ -1,0 +1,138 @@
+// 📌 Module : Réceptions - Tests Widget Détail
+// 🧭 Description : Tests widget pour l'écran de détail des réceptions
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ml_pp_mvp/features/receptions/screens/reception_detail_screen.dart';
+import 'package:ml_pp_mvp/features/receptions/providers/receptions_table_provider.dart';
+import 'package:ml_pp_mvp/features/receptions/models/reception_row_vm.dart';
+import 'package:ml_pp_mvp/features/profil/providers/profil_provider.dart';
+import 'package:ml_pp_mvp/core/models/user_role.dart';
+
+void main() {
+  group('ReceptionDetailScreen', () {
+    testWidgets(
+      'Réception Detail (Directeur) ne montre pas le bouton Ajustement',
+      (tester) async {
+        // Arrange
+        final reception = ReceptionRowVM(
+          id: 'test-id',
+          dateReception: DateTime(2025, 1, 15),
+          propriete: 'MONALUXE',
+          produitLabel: 'ESS · Essence',
+          citerneNom: 'Citerne 1',
+          vol15: 1000.0,
+          volAmb: 1000.0,
+          fournisseurNom: 'Fournisseur Test',
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            receptionsTableProvider.overrideWith((ref) async => [reception]),
+            userRoleProvider.overrideWith((ref) => UserRole.directeur),
+          ],
+        );
+
+        // Act
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(
+              home: ReceptionDetailScreen(receptionId: 'test-id'),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.text('Corriger (Ajustement)'), findsNothing);
+        expect(find.byIcon(Icons.tune), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Admin voit le bouton Ajustement',
+      (tester) async {
+        // Arrange
+        final reception = ReceptionRowVM(
+          id: 'test-id',
+          dateReception: DateTime(2025, 1, 15),
+          propriete: 'MONALUXE',
+          produitLabel: 'ESS · Essence',
+          citerneNom: 'Citerne 1',
+          vol15: 1000.0,
+          volAmb: 1000.0,
+          fournisseurNom: 'Fournisseur Test',
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            receptionsTableProvider.overrideWith((ref) async => [reception]),
+            userRoleProvider.overrideWith((ref) => UserRole.admin),
+          ],
+        );
+
+        // Act
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(
+              home: ReceptionDetailScreen(receptionId: 'test-id'),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.byIcon(Icons.tune), findsOneWidget);
+        expect(
+          find.descendant(
+            of: find.byType(AppBar),
+            matching: find.byIcon(Icons.tune),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'Réception Detail (Gérant) ne montre pas le bouton Ajustement',
+      (tester) async {
+        // Arrange
+        final reception = ReceptionRowVM(
+          id: 'test-id',
+          dateReception: DateTime(2025, 1, 15),
+          propriete: 'MONALUXE',
+          produitLabel: 'ESS · Essence',
+          citerneNom: 'Citerne 1',
+          vol15: 1000.0,
+          volAmb: 1000.0,
+          fournisseurNom: 'Fournisseur Test',
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            receptionsTableProvider.overrideWith((ref) async => [reception]),
+            userRoleProvider.overrideWith((ref) => UserRole.gerant),
+          ],
+        );
+
+        // Act
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(
+              home: ReceptionDetailScreen(receptionId: 'test-id'),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.text('Corriger (Ajustement)'), findsNothing);
+        expect(find.byIcon(Icons.tune), findsNothing);
+      },
+    );
+  });
+}

--- a/test/features/sorties/screens/sortie_detail_screen_test.dart
+++ b/test/features/sorties/screens/sortie_detail_screen_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ml_pp_mvp/features/sorties/models/sortie_row_vm.dart';
 import 'package:ml_pp_mvp/features/sorties/providers/sorties_table_provider.dart';
 import 'package:ml_pp_mvp/features/sorties/screens/sortie_detail_screen.dart';
+import 'package:ml_pp_mvp/features/profil/providers/profil_provider.dart';
+import 'package:ml_pp_mvp/core/models/user_role.dart';
 
 void main() {
   group('SortieDetailScreen', () {
@@ -289,5 +291,125 @@ void main() {
 
       // Assert: Le bouton est présent et cliquable (pas de crash)
     });
+
+    testWidgets(
+      'Sortie Detail (Directeur) ne montre pas le bouton Ajustement',
+      (tester) async {
+        // Arrange
+        final sortie = SortieRowVM(
+          id: 'test-id',
+          dateSortie: DateTime(2025, 1, 15),
+          propriete: 'MONALUXE',
+          produitLabel: 'ESS · Essence',
+          citerneNom: 'Citerne 1',
+          vol15: 1000.0,
+          volAmb: 1000.0,
+          beneficiaireNom: 'Client Test',
+          statut: 'validee',
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            sortiesTableProvider.overrideWith((ref) async => [sortie]),
+            userRoleProvider.overrideWith((ref) => UserRole.directeur),
+          ],
+        );
+
+        // Act
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(home: SortieDetailScreen(sortieId: 'test-id')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.text('Corriger (Ajustement)'), findsNothing);
+        expect(find.byIcon(Icons.tune), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Admin voit le bouton Ajustement',
+      (tester) async {
+        // Arrange
+        final sortie = SortieRowVM(
+          id: 'test-id',
+          dateSortie: DateTime(2025, 1, 15),
+          propriete: 'MONALUXE',
+          produitLabel: 'ESS · Essence',
+          citerneNom: 'Citerne 1',
+          vol15: 1000.0,
+          volAmb: 1000.0,
+          beneficiaireNom: 'Client Test',
+          statut: 'validee',
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            sortiesTableProvider.overrideWith((ref) async => [sortie]),
+            userRoleProvider.overrideWith((ref) => UserRole.admin),
+          ],
+        );
+
+        // Act
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(home: SortieDetailScreen(sortieId: 'test-id')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.byIcon(Icons.tune), findsOneWidget);
+        expect(
+          find.descendant(
+            of: find.byType(AppBar),
+            matching: find.byIcon(Icons.tune),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'Sortie Detail (Gérant) ne montre pas le bouton Ajustement',
+      (tester) async {
+        // Arrange
+        final sortie = SortieRowVM(
+          id: 'test-id',
+          dateSortie: DateTime(2025, 1, 15),
+          propriete: 'MONALUXE',
+          produitLabel: 'ESS · Essence',
+          citerneNom: 'Citerne 1',
+          vol15: 1000.0,
+          volAmb: 1000.0,
+          beneficiaireNom: 'Client Test',
+          statut: 'validee',
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            sortiesTableProvider.overrideWith((ref) async => [sortie]),
+            userRoleProvider.overrideWith((ref) => UserRole.gerant),
+          ],
+        );
+
+        // Act
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(home: SortieDetailScreen(sortieId: 'test-id')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.text('Corriger (Ajustement)'), findsNothing);
+        expect(find.byIcon(Icons.tune), findsNothing);
+      },
+    );
   });
 }

--- a/test/features/sorties/screens/sortie_list_screen_test.dart
+++ b/test/features/sorties/screens/sortie_list_screen_test.dart
@@ -1,0 +1,98 @@
+// 📌 Module : Sorties - Tests Widget Liste
+// 🧭 Description : Tests widget pour l'écran de liste des sorties
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ml_pp_mvp/features/sorties/screens/sortie_list_screen.dart';
+import 'package:ml_pp_mvp/features/sorties/providers/sorties_table_provider.dart';
+import 'package:ml_pp_mvp/features/sorties/models/sortie_row_vm.dart';
+import 'package:ml_pp_mvp/features/profil/providers/profil_provider.dart';
+import 'package:ml_pp_mvp/core/models/user_role.dart';
+
+/// Helper pour créer un dataset avec exactement `count` lignes
+List<SortieRowVM> _mockRows({
+  required int count,
+  required SortieRowVM Function(int i) factory,
+}) {
+  return List.generate(count, factory);
+}
+
+/// Factory simple de base pour les lignes
+SortieRowVM _baseRow(int i) => SortieRowVM(
+      id: 'sortie-$i',
+      dateSortie: DateTime(2026, 1, 1).add(Duration(days: i)),
+      propriete: 'MONALUXE',
+      produitLabel: 'Essence',
+      citerneNom: 'Citerne $i',
+      vol15: 1000.0 + i,
+      volAmb: 1000.0 + i,
+      beneficiaireNom: 'Client $i',
+      statut: 'validee',
+    );
+
+void main() {
+  group('SortieListScreen', () {
+    testWidgets(
+      'Sorties List (PCA) n\'affiche aucun bouton d\'action',
+      (tester) async {
+        // Arrange - Créer des données mockées avec >= 10 lignes
+        final mockSorties = _mockRows(count: 10, factory: (i) => _baseRow(i));
+
+        // Forcer un layout déterministe (desktop) pour garantir le rendu table
+        await tester.binding.setSurfaceSize(const Size(1300, 800));
+        addTearDown(() async {
+          await tester.binding.setSurfaceSize(null);
+        });
+
+        // Act - Monter l'écran avec le provider override et rôle PCA
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sortiesTableProvider.overrideWith(
+                (ref) => Future.value(mockSorties),
+              ),
+              userRoleProvider.overrideWith((ref) => UserRole.pca),
+            ],
+            child: const MaterialApp(home: SortieListScreen()),
+          ),
+        );
+
+        // Attendre que les données soient chargées
+        await tester.pumpAndSettle();
+
+        // Assert - Vérifier que les boutons d'action ne sont pas présents
+        expect(
+          find.byIcon(Icons.add),
+          findsNothing,
+          reason: 'Le bouton "+" ne doit pas être affiché pour le rôle PCA',
+        );
+
+        expect(
+          find.byIcon(Icons.add_rounded),
+          findsNothing,
+          reason: 'Le bouton "+" (rounded) ne doit pas être affiché pour le rôle PCA',
+        );
+
+        expect(
+          find.text('Actions'),
+          findsNothing,
+          reason: 'La colonne "Actions" ne doit pas être affichée pour le rôle PCA',
+        );
+
+        expect(
+          find.byIcon(Icons.edit),
+          findsNothing,
+          reason: 'Aucune icône "edit" ne doit être affichée pour le rôle PCA',
+        );
+
+        // Vérifier que l'écran se charge correctement malgré tout
+        expect(
+          find.byType(SortieListScreen),
+          findsOneWidget,
+          reason: 'L\'écran de liste doit être affiché même pour PCA',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Rôles & Permissions UI

### PCA
- Lecture seule sur CDR, Réceptions, Sorties
- Aucune action de création / modification
- Tests UI ajoutés et validés

### Directeur
- Création et validation Réceptions & Sorties
- Ajustements interdits (Admin only)
- Comportement validé par tests UI

### Gérant
- Lecture seule sur CDR
- Création & validation Réceptions / Sorties
- Ajustements interdits (Admin only)
- Tests UI ajoutés et validés

### UI / Mobile
- Correction overflow & écran blanc sur détail CDR
- Timeline responsive (Wrap mobile / Row desktop)
- Aucun impact desktop

### Qualité
- Tous les tests au vert
- Changelog + docs Prod Ready mis à jour
