### PR TITLE
test: stabilize fakes and remove network-like noise in auth tests

### DIFF
--- a/test/features/auth/auth_service_test.dart
+++ b/test/features/auth/auth_service_test.dart
@@ -216,7 +216,7 @@ void main() {
         when(mockClient.auth).thenReturn(mockAuth);
         when(
           mockAuth.signInWithPassword(email: email, password: password),
-        ).thenThrow(Exception('Network error'));
+        ).thenThrow(Exception('Unexpected error'));
 
         // Act & Assert
         expect(
@@ -225,7 +225,7 @@ void main() {
             isA<Exception>().having(
               (e) => e.toString(),
               'toString',
-              contains('Network error'),
+              contains('Unexpected error'),
             ),
           ),
         );
@@ -268,7 +268,7 @@ void main() {
       test('should rethrow generic exceptions', () async {
         // Arrange
         when(mockClient.auth).thenReturn(mockAuth);
-        when(mockAuth.signOut()).thenThrow(Exception('Network error'));
+        when(mockAuth.signOut()).thenThrow(Exception('Unexpected error'));
 
         // Act & Assert
         expect(
@@ -277,7 +277,7 @@ void main() {
             isA<Exception>().having(
               (e) => e.toString(),
               'toString',
-              contains('Network error'),
+              contains('Unexpected error'),
             ),
           ),
         );

--- a/test/features/stocks/stocks_kpi_repository_test.dart
+++ b/test/features/stocks/stocks_kpi_repository_test.dart
@@ -43,7 +43,27 @@ class _FakeFilterBuilder<T> implements PostgrestFilterBuilder<T> {
   }
 
   @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+  dynamic noSuchMethod(Invocation invocation) {
+    // Gérer maybeSingle() pour le fallback snapshot
+    // Note: Le as dynamic est volontaire pour gérer les variations de types Supabase
+    if (invocation.isMethod && invocation.memberName == #maybeSingle) {
+      final dynamic v = _result;
+
+      // Cas classique Supabase : le builder a une List<Map> et maybeSingle doit renvoyer
+      // - null si vide
+      // - le premier élément si non vide
+      if (v is List) {
+        if (v.isEmpty) {
+          return _FakeFilterBuilder<Map<String, dynamic>?>(null) as dynamic;
+        }
+        return _FakeFilterBuilder<Map<String, dynamic>?>(v.first as Map<String, dynamic>?) as dynamic;
+      }
+
+      // Sinon, renvoyer tel quel
+      return _FakeFilterBuilder<Map<String, dynamic>?>(v as Map<String, dynamic>?) as dynamic;
+    }
+    return super.noSuchMethod(invocation);
+  }
 }
 
 /// Wrapper pour from() qui implémente SupabaseQueryBuilder


### PR DESCRIPTION
## 🎯 Objectif
Stabiliser les tests unitaires post-D1 en supprimant tout bruit assimilable à des appels réseau ou à des effets non déterministes.

## 🧩 Changements
- Stabilisation des fakes dans `AuthService` (exceptions génériques explicites)
- Suppression des messages et comportements pouvant simuler un échec réseau
- Tests strictement déterministes (unitaires purs)

## ✅ Vérifications
- `flutter test test/features/auth/auth_service_test.dart` ✅
- `flutter test test/features/stocks/stocks_kpi_repository_test.dart` ✅
- Aucun impact sur la logique métier ou la production

## 🛡️ Risque
Nul — changements limités aux tests uniquement.
