### PR TITLE
Security: harden profil update + stabilize stock owner snapshot view

### DIFF
--- a/supabase/migrations/20251227_create_v_stock_actuel_owner_snapshot.sql
+++ b/supabase/migrations/20251227_create_v_stock_actuel_owner_snapshot.sql
@@ -8,6 +8,9 @@
 -- Retourne le dernier état connu de chaque combinaison (citerne, produit, propriétaire)
 -- et agrège par (dépôt, produit, propriétaire)
 
+DROP VIEW IF EXISTS public.v_stock_actuel_owner_snapshot;
+-- (no CASCADE: verified no dependencies)
+
 CREATE OR REPLACE VIEW public.v_stock_actuel_owner_snapshot AS
 WITH base AS (
   SELECT 


### PR DESCRIPTION
This PR contains two focused changes:

1) Security (client-side hardening)
- Whitelist safe fields in ProfilService.updateProfil
- Prevent clients from sending sensitive fields (role, depot_id, user_id, created_at, etc.)
- Defense-in-depth on top of RLS

2) Database view stability
- Recreate v_stock_actuel_owner_snapshot deterministically
- Avoid view definition drift between local and deployed environments

Notes:
- No dependency updates
- No schema changes beyond view recreation
- pubspec.lock intentionally untouched
