### PR TITLE
CI: make DB test opt-in (skip when RUN_DB_TESTS!=1)

### DIFF
--- a/test/integration/sortie_stock_log_test.dart
+++ b/test/integration/sortie_stock_log_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -155,7 +157,11 @@ Future<void> ensureProfilRole({
 }
 
 void main() {
-  test('[DB-TEST] B2.2 Sortie -> Stock -> Log (STAGING, DB-STRICT)', () async {
+  final runDbTests = Platform.environment['RUN_DB_TESTS'] == '1';
+
+  test(
+    '[DB-TEST] B2.2 Sortie -> Stock -> Log (STAGING, DB-STRICT)',
+    () async {
     final staging = await StagingSupabase.create(envPath: 'env/.env.staging');
     final env = await StagingEnv.load(path: 'env/.env.staging');
     
@@ -371,6 +377,10 @@ void main() {
 
     // ignore: avoid_print
     print('[DB-TEST] B2.2 OK — debit & reject verified (tag=${ids.tag})');
-  });
+    },
+    skip: runDbTests
+        ? false
+        : 'DB tests disabled (set RUN_DB_TESTS=1 and provide env/.env.staging or dart-defines)',
+  );
 }
 


### PR DESCRIPTION
### Context
Flutter CI Nightly (Full Suite) was failing on `main` because a DB integration test
(`[DB-TEST] B2.2 Sortie -> Stock -> Log`) was executed in CI without a staging
environment file (`env/.env.staging`), causing a hard failure.

### Root cause
The test was missing a proper opt-in guard and attempted to load staging
credentials even when `RUN_DB_TESTS` was not enabled.

### Fix
- Make the DB integration test explicitly opt-in.
- Skip the test unless `RUN_DB_TESTS=1` is set.

### Impact
- Nightly CI no longer fails due to missing local staging env.
- DB integration tests remain available locally and in controlled environments.
- No production code or business logic affected.
