### PR TITLE
docs(staging): clarify prod-like seed usage in reset_staging script

### DIFF
--- a/scripts/reset_staging.sh
+++ b/scripts/reset_staging.sh
@@ -7,6 +7,12 @@ set -euo pipefail
 #     ALLOW_STAGING_RESET=true \
 #     ./scripts/reset_staging.sh
 #
+#   Reset avec seed prod-like (tests métier / GO PROD):
+#     CONFIRM_STAGING_RESET=I_UNDERSTAND_THIS_WILL_DROP_PUBLIC \
+#     ALLOW_STAGING_RESET=true \
+#     SEED_FILE=staging/sql/seed_staging_prod_like.sql \
+#     ./scripts/reset_staging.sh
+#
 #   Reset avec seed minimal (pour DB-tests):
 #     CONFIRM_STAGING_RESET=I_UNDERSTAND_THIS_WILL_DROP_PUBLIC \
 #     ALLOW_STAGING_RESET=true \


### PR DESCRIPTION
## Contexte
Après l’introduction du seed STAGING prod-like (opt-in), le script
`scripts/reset_staging.sh` ne documentait pas explicitement son usage.

## Changement
- Ajout d’un exemple clair d’utilisation du seed prod-like dans la section
  `Usage` du script `reset_staging.sh`.

## Impact
- Aucun changement de logique.
- Amélioration de la lisibilité pour les développeurs et les outils IA.
- Réduction du risque d’erreur humaine lors des resets STAGING.

## Statut
- Documentation uniquement
- Prêt à merger après CI
