### PR TITLE
ci(logging): reduce test noise and harden D4 release gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,19 @@ Validation locale confirmée :
 
 ## [Unreleased]
 
+### 🔧 **Réduction bruit logs tests — 2026-01-27**
+
+#### **Amélioration logging**
+- **Problème** : Logs verbeux (`debugPrint`) pendant l'exécution des tests (CI et local), polluant les sorties
+- **Solution** :
+  - Mise à jour de `appLog()` pour être silencieux en CI et en tests (détection via `Platform.environment['CI']`)
+  - Remplacement des `debugPrint()` verbeux par `appLog()` dans :
+    - `OwnerStockBreakdownCard` (stocks_kpi_cards.dart)
+    - `depotOwnerStockFromSnapshotProvider` (stocks_kpi_providers.dart)
+    - Logs de payload [AXE A][stocks_adjustments] (stocks_adjustments_service.dart)
+- **Résultat** : Logs silencieux en CI/tests, toujours actifs en développement local
+- **Impact** : Aucun changement fonctionnel, réduction du bruit dans les logs de tests
+
 ### 🚀 **[GO PROD] — Finalisation Documentation & Validation — 2026-01-24**
 
 #### **Clarification périmètre MVP**

--- a/lib/shared/utils/app_log.dart
+++ b/lib/shared/utils/app_log.dart
@@ -1,23 +1,34 @@
 // 📌 Module : Utils - App Logging
 // 🧭 Description : Helper pour le logging en mode développement uniquement
 // 🚫 PROD-SAFE: Les logs ne s'affichent qu'en mode debug, pas en production
+// 🚫 CI-SAFE: Les logs sont silencieux en CI et en tests pour réduire le bruit
 
+import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart';
 
-/// Log un message en mode développement uniquement
+/// Log un message en mode développement uniquement (silencieux en CI/tests)
 ///
-/// Cette fonction utilise `assert()` avec `debugPrint()` pour garantir
-/// que les logs ne s'affichent qu'en mode debug et sont complètement
-/// supprimés en production (tree-shaking).
+/// Cette fonction utilise `debugPrint()` uniquement si :
+/// - `kDebugMode == true` (mode développement)
+/// - ET `Platform.environment['CI'] != 'true'` (pas en CI)
+///
+/// En tests et CI, cette fonction est silencieuse pour réduire le bruit.
+/// En production, les logs sont complètement supprimés (tree-shaking).
 ///
 /// Usage:
 /// ```dart
 /// appLog('Erreur lors de l\'enregistrement: $error');
 /// ```
 void appLog(String message) {
-  assert(() {
-    debugPrint(message);
-    return true;
-  }());
+  // Silencieux en production (kDebugMode == false)
+  if (!kDebugMode) return;
+
+  // Silencieux en CI et en tests (détection via variable d'environnement)
+  final isCI = Platform.environment['CI'] == 'true' ||
+      Platform.environment['CONTINUOUS_INTEGRATION'] == 'true';
+  if (isCI) return;
+
+  // Afficher uniquement en développement local
+  debugPrint(message);
 }
 


### PR DESCRIPTION
Reduce noisy logs in CI/tests via appLog behavior (silent in CI/tests, active in debug)
Harden d4_release_gate.sh:
Avoid broken pipe when capturing Flutter version
Don’t fail release gate on analyze infos/warnings (keep errors blocking)
Goal: keep release gate signal clean and prod-focused, without touching functional behavior.