### PR TITLE
chore(android): align NDK to 28.2.13676358

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.ml_pp_mvp"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "28.2.13676358"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
CONTEXTE
Build Android debug OK, mais warning NDK détecté :
integration_test requiert NDK 28.2.13676358.

CHANGEMENT
- Alignement explicite de ndkVersion dans android/app/build.gradle.kts.

GARDE-FOUS
- Aucun changement fonctionnel
- Aucun impact runtime
- Android uniquement
- Compatible CI / release

STATUT
flutter build apk --debug : OK
Warning NDK : résolu
