### PR TITLE
feat(fournisseurs): add read-only suppliers module (list, detail, tests)

### DIFF
--- a/lib/features/fournisseurs/data/repositories/supabase_fournisseur_repository.dart
+++ b/lib/features/fournisseurs/data/repositories/supabase_fournisseur_repository.dart
@@ -1,0 +1,54 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../domain/models/fournisseur.dart';
+import '../../domain/repositories/fournisseur_repository.dart';
+
+/// Implémentation read-only du repository fournisseurs via Supabase.
+/// Utilise un [SupabaseClient] injecté (pas Supabase.instance en dur).
+class SupabaseFournisseurRepository implements FournisseurRepository {
+  final SupabaseClient _client;
+
+  SupabaseFournisseurRepository(this._client);
+
+  static const _selectColumns =
+      'id, nom, contact_personne, email, telephone, adresse, pays, note_supplementaire, created_at';
+
+  @override
+  Future<List<Fournisseur>> fetchAllFournisseurs() async {
+    try {
+      final res = await _client
+          .from('fournisseurs')
+          .select(_selectColumns)
+          .order('nom', ascending: true);
+
+      final list = res as List;
+      return list
+          .map((e) =>
+              Fournisseur.fromJson(Map<String, dynamic>.from(e as Map)))
+          .toList();
+    } on PostgrestException catch (e) {
+      throw Exception('Fournisseurs fetchAllFournisseurs: ${e.message}');
+    } catch (e) {
+      throw Exception('Fournisseurs fetchAllFournisseurs: $e');
+    }
+  }
+
+  @override
+  Future<Fournisseur?> getById(String id) async {
+    if (id.isEmpty) return null;
+    try {
+      final res = await _client
+          .from('fournisseurs')
+          .select(_selectColumns)
+          .eq('id', id)
+          .maybeSingle();
+
+      if (res == null) return null;
+      return Fournisseur.fromJson(Map<String, dynamic>.from(res as Map));
+    } on PostgrestException catch (e) {
+      throw Exception('Fournisseur getById: ${e.message}');
+    } catch (e) {
+      throw Exception('Fournisseur getById: $e');
+    }
+  }
+}

--- a/lib/features/fournisseurs/domain/models/fournisseur.dart
+++ b/lib/features/fournisseurs/domain/models/fournisseur.dart
@@ -1,0 +1,26 @@
+// Module Fournisseurs — Sprint 1 (lecture seule).
+// Source de vérité : public.fournisseurs. Champs exacts, pas de status/actif.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'fournisseur.freezed.dart';
+part 'fournisseur.g.dart';
+
+/// Modèle immutable d'un fournisseur (table public.fournisseurs).
+@freezed
+class Fournisseur with _$Fournisseur {
+  const factory Fournisseur({
+    required String id,
+    required String nom,
+    @JsonKey(name: 'contact_personne') String? contactPersonne,
+    String? email,
+    String? telephone,
+    String? adresse,
+    String? pays,
+    @JsonKey(name: 'note_supplementaire') String? noteSupplementaire,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+  }) = _Fournisseur;
+
+  factory Fournisseur.fromJson(Map<String, dynamic> json) =>
+      _$FournisseurFromJson(json);
+}

--- a/lib/features/fournisseurs/domain/models/fournisseur.freezed.dart
+++ b/lib/features/fournisseurs/domain/models/fournisseur.freezed.dart
@@ -1,0 +1,363 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'fournisseur.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+Fournisseur _$FournisseurFromJson(Map<String, dynamic> json) {
+  return _Fournisseur.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Fournisseur {
+  String get id => throw _privateConstructorUsedError;
+  String get nom => throw _privateConstructorUsedError;
+  @JsonKey(name: 'contact_personne')
+  String? get contactPersonne => throw _privateConstructorUsedError;
+  String? get email => throw _privateConstructorUsedError;
+  String? get telephone => throw _privateConstructorUsedError;
+  String? get adresse => throw _privateConstructorUsedError;
+  String? get pays => throw _privateConstructorUsedError;
+  @JsonKey(name: 'note_supplementaire')
+  String? get noteSupplementaire => throw _privateConstructorUsedError;
+  @JsonKey(name: 'created_at')
+  DateTime? get createdAt => throw _privateConstructorUsedError;
+
+  /// Serializes this Fournisseur to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Fournisseur
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $FournisseurCopyWith<Fournisseur> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $FournisseurCopyWith<$Res> {
+  factory $FournisseurCopyWith(
+    Fournisseur value,
+    $Res Function(Fournisseur) then,
+  ) = _$FournisseurCopyWithImpl<$Res, Fournisseur>;
+  @useResult
+  $Res call({
+    String id,
+    String nom,
+    @JsonKey(name: 'contact_personne') String? contactPersonne,
+    String? email,
+    String? telephone,
+    String? adresse,
+    String? pays,
+    @JsonKey(name: 'note_supplementaire') String? noteSupplementaire,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+  });
+}
+
+/// @nodoc
+class _$FournisseurCopyWithImpl<$Res, $Val extends Fournisseur>
+    implements $FournisseurCopyWith<$Res> {
+  _$FournisseurCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Fournisseur
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? nom = null,
+    Object? contactPersonne = freezed,
+    Object? email = freezed,
+    Object? telephone = freezed,
+    Object? adresse = freezed,
+    Object? pays = freezed,
+    Object? noteSupplementaire = freezed,
+    Object? createdAt = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            nom: null == nom
+                ? _value.nom
+                : nom // ignore: cast_nullable_to_non_nullable
+                      as String,
+            contactPersonne: freezed == contactPersonne
+                ? _value.contactPersonne
+                : contactPersonne // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            email: freezed == email
+                ? _value.email
+                : email // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            telephone: freezed == telephone
+                ? _value.telephone
+                : telephone // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            adresse: freezed == adresse
+                ? _value.adresse
+                : adresse // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            pays: freezed == pays
+                ? _value.pays
+                : pays // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            noteSupplementaire: freezed == noteSupplementaire
+                ? _value.noteSupplementaire
+                : noteSupplementaire // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            createdAt: freezed == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$FournisseurImplCopyWith<$Res>
+    implements $FournisseurCopyWith<$Res> {
+  factory _$$FournisseurImplCopyWith(
+    _$FournisseurImpl value,
+    $Res Function(_$FournisseurImpl) then,
+  ) = __$$FournisseurImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String nom,
+    @JsonKey(name: 'contact_personne') String? contactPersonne,
+    String? email,
+    String? telephone,
+    String? adresse,
+    String? pays,
+    @JsonKey(name: 'note_supplementaire') String? noteSupplementaire,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+  });
+}
+
+/// @nodoc
+class __$$FournisseurImplCopyWithImpl<$Res>
+    extends _$FournisseurCopyWithImpl<$Res, _$FournisseurImpl>
+    implements _$$FournisseurImplCopyWith<$Res> {
+  __$$FournisseurImplCopyWithImpl(
+    _$FournisseurImpl _value,
+    $Res Function(_$FournisseurImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of Fournisseur
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? nom = null,
+    Object? contactPersonne = freezed,
+    Object? email = freezed,
+    Object? telephone = freezed,
+    Object? adresse = freezed,
+    Object? pays = freezed,
+    Object? noteSupplementaire = freezed,
+    Object? createdAt = freezed,
+  }) {
+    return _then(
+      _$FournisseurImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        nom: null == nom
+            ? _value.nom
+            : nom // ignore: cast_nullable_to_non_nullable
+                  as String,
+        contactPersonne: freezed == contactPersonne
+            ? _value.contactPersonne
+            : contactPersonne // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        email: freezed == email
+            ? _value.email
+            : email // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        telephone: freezed == telephone
+            ? _value.telephone
+            : telephone // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        adresse: freezed == adresse
+            ? _value.adresse
+            : adresse // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        pays: freezed == pays
+            ? _value.pays
+            : pays // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        noteSupplementaire: freezed == noteSupplementaire
+            ? _value.noteSupplementaire
+            : noteSupplementaire // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        createdAt: freezed == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$FournisseurImpl implements _Fournisseur {
+  const _$FournisseurImpl({
+    required this.id,
+    required this.nom,
+    @JsonKey(name: 'contact_personne') this.contactPersonne,
+    this.email,
+    this.telephone,
+    this.adresse,
+    this.pays,
+    @JsonKey(name: 'note_supplementaire') this.noteSupplementaire,
+    @JsonKey(name: 'created_at') this.createdAt,
+  });
+
+  factory _$FournisseurImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FournisseurImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String nom;
+  @override
+  @JsonKey(name: 'contact_personne')
+  final String? contactPersonne;
+  @override
+  final String? email;
+  @override
+  final String? telephone;
+  @override
+  final String? adresse;
+  @override
+  final String? pays;
+  @override
+  @JsonKey(name: 'note_supplementaire')
+  final String? noteSupplementaire;
+  @override
+  @JsonKey(name: 'created_at')
+  final DateTime? createdAt;
+
+  @override
+  String toString() {
+    return 'Fournisseur(id: $id, nom: $nom, contactPersonne: $contactPersonne, email: $email, telephone: $telephone, adresse: $adresse, pays: $pays, noteSupplementaire: $noteSupplementaire, createdAt: $createdAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FournisseurImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.nom, nom) || other.nom == nom) &&
+            (identical(other.contactPersonne, contactPersonne) ||
+                other.contactPersonne == contactPersonne) &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.telephone, telephone) ||
+                other.telephone == telephone) &&
+            (identical(other.adresse, adresse) || other.adresse == adresse) &&
+            (identical(other.pays, pays) || other.pays == pays) &&
+            (identical(other.noteSupplementaire, noteSupplementaire) ||
+                other.noteSupplementaire == noteSupplementaire) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    nom,
+    contactPersonne,
+    email,
+    telephone,
+    adresse,
+    pays,
+    noteSupplementaire,
+    createdAt,
+  );
+
+  /// Create a copy of Fournisseur
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FournisseurImplCopyWith<_$FournisseurImpl> get copyWith =>
+      __$$FournisseurImplCopyWithImpl<_$FournisseurImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$FournisseurImplToJson(this);
+  }
+}
+
+abstract class _Fournisseur implements Fournisseur {
+  const factory _Fournisseur({
+    required final String id,
+    required final String nom,
+    @JsonKey(name: 'contact_personne') final String? contactPersonne,
+    final String? email,
+    final String? telephone,
+    final String? adresse,
+    final String? pays,
+    @JsonKey(name: 'note_supplementaire') final String? noteSupplementaire,
+    @JsonKey(name: 'created_at') final DateTime? createdAt,
+  }) = _$FournisseurImpl;
+
+  factory _Fournisseur.fromJson(Map<String, dynamic> json) =
+      _$FournisseurImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get nom;
+  @override
+  @JsonKey(name: 'contact_personne')
+  String? get contactPersonne;
+  @override
+  String? get email;
+  @override
+  String? get telephone;
+  @override
+  String? get adresse;
+  @override
+  String? get pays;
+  @override
+  @JsonKey(name: 'note_supplementaire')
+  String? get noteSupplementaire;
+  @override
+  @JsonKey(name: 'created_at')
+  DateTime? get createdAt;
+
+  /// Create a copy of Fournisseur
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$FournisseurImplCopyWith<_$FournisseurImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/fournisseurs/domain/models/fournisseur.g.dart
+++ b/lib/features/fournisseurs/domain/models/fournisseur.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'fournisseur.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$FournisseurImpl _$$FournisseurImplFromJson(Map<String, dynamic> json) =>
+    _$FournisseurImpl(
+      id: json['id'] as String,
+      nom: json['nom'] as String,
+      contactPersonne: json['contact_personne'] as String?,
+      email: json['email'] as String?,
+      telephone: json['telephone'] as String?,
+      adresse: json['adresse'] as String?,
+      pays: json['pays'] as String?,
+      noteSupplementaire: json['note_supplementaire'] as String?,
+      createdAt: json['created_at'] == null
+          ? null
+          : DateTime.parse(json['created_at'] as String),
+    );
+
+Map<String, dynamic> _$$FournisseurImplToJson(_$FournisseurImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'nom': instance.nom,
+      'contact_personne': instance.contactPersonne,
+      'email': instance.email,
+      'telephone': instance.telephone,
+      'adresse': instance.adresse,
+      'pays': instance.pays,
+      'note_supplementaire': instance.noteSupplementaire,
+      'created_at': instance.createdAt?.toIso8601String(),
+    };

--- a/lib/features/fournisseurs/domain/repositories/fournisseur_repository.dart
+++ b/lib/features/fournisseurs/domain/repositories/fournisseur_repository.dart
@@ -1,0 +1,12 @@
+import '../models/fournisseur.dart';
+
+/// Repository lecture seule pour le référentiel fournisseurs.
+/// Sprint 1 : aucune mutation (create/update/delete).
+abstract class FournisseurRepository {
+  /// Récupère tous les fournisseurs (tri côté DB par nom).
+  /// Extensible pour pagination future (profil M).
+  Future<List<Fournisseur>> fetchAllFournisseurs();
+
+  /// Récupère un fournisseur par id, ou null si absent.
+  Future<Fournisseur?> getById(String id);
+}

--- a/lib/features/fournisseurs/presentation/screens/fournisseur_detail_screen.dart
+++ b/lib/features/fournisseurs/presentation/screens/fournisseur_detail_screen.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../providers/fournisseur_providers.dart';
+
+/// Format created_at lisible (dd/MM/yyyy HH:mm). Fallback si intl indisponible.
+String? _formatCreatedAt(DateTime? d) {
+  if (d == null) return null;
+  try {
+    return DateFormat('dd/MM/yyyy HH:mm').format(d);
+  } catch (_) {
+    return '${d.day.toString().padLeft(2, '0')}/${d.month.toString().padLeft(2, '0')}/${d.year} ${d.hour.toString().padLeft(2, '0')}:${d.minute.toString().padLeft(2, '0')}';
+  }
+}
+
+/// Écran détail fournisseur (Sprint 1 — lecture seule).
+/// Sections: Informations, Adresse, Notes, Métadonnées + placeholders ERP.
+class FournisseurDetailScreen extends ConsumerWidget {
+  const FournisseurDetailScreen({super.key, required this.fournisseurId});
+
+  final String fournisseurId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncDetail = ref.watch(fournisseurDetailProvider(fournisseurId));
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: asyncDetail.when(
+          data: (f) => Text(f?.nom ?? 'Fournisseur'),
+          loading: () => const Text('Fournisseur'),
+          error: (_, __) => const Text('Fournisseur'),
+        ),
+      ),
+      body: asyncDetail.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => _buildError(context, ref, err),
+        data: (f) {
+          if (f == null) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.person_off_outlined,
+                    size: 64,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Fournisseur introuvable',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ],
+              ),
+            );
+          }
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _buildActifBadge(context),
+                const SizedBox(height: 16),
+                _buildSection(
+                  context,
+                  'Informations',
+                  [
+                    _row(context, 'Nom', f.nom),
+                    _row(context, 'Pays', f.pays),
+                    _row(context, 'Contact', f.contactPersonne),
+                    _row(context, 'Email', f.email),
+                    _row(context, 'Téléphone', f.telephone),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                _buildSection(
+                  context,
+                  'Adresse',
+                  [_row(context, 'Adresse', f.adresse)],
+                ),
+                const SizedBox(height: 16),
+                _buildSection(
+                  context,
+                  'Notes',
+                  [_row(context, 'Note supplémentaire', f.noteSupplementaire)],
+                ),
+                const SizedBox(height: 16),
+                _buildSection(
+                  context,
+                  'Métadonnées',
+                  [
+                    _row(context, 'ID', f.id),
+                    _row(
+                      context,
+                      'Créé le',
+                      _formatCreatedAt(f.createdAt),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                _buildPlaceholderCard(
+                  context,
+                  'SBLC — Sprint 2',
+                  'Non implémenté (Sprint 2)',
+                ),
+                const SizedBox(height: 12),
+                _buildPlaceholderCard(
+                  context,
+                  'Proformas — Sprint 2/3',
+                  'Non implémenté (Sprint 2/3)',
+                ),
+                const SizedBox(height: 12),
+                _buildPlaceholderCard(
+                  context,
+                  'Factures finales — Sprint 3/4',
+                  'Non implémenté (Sprint 3/4)',
+                ),
+                const SizedBox(height: 12),
+                _buildPlaceholderCard(
+                  context,
+                  'Relevé fournisseur — Sprint 4',
+                  'Non implémenté (Sprint 4)',
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildActifBadge(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primaryContainer,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          'ACTIF',
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.onPrimaryContainer,
+              ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection(
+    BuildContext context,
+    String title,
+    List<Widget> rows,
+  ) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 12),
+            ...rows,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _row(BuildContext context, String label, String? value) {
+    if (value == null || value.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 140,
+            child: Text(
+              '$label :',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+          Expanded(child: Text(value)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlaceholderCard(
+    BuildContext context,
+    String title,
+    String body,
+  ) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              body,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildError(BuildContext context, WidgetRef ref, Object err) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 64,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              err.toString(),
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: () =>
+                  ref.invalidate(fournisseurDetailProvider(fournisseurId)),
+              icon: const Icon(Icons.refresh),
+              label: const Text('Réessayer'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/fournisseurs/presentation/screens/fournisseurs_list_screen.dart
+++ b/lib/features/fournisseurs/presentation/screens/fournisseurs_list_screen.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../domain/models/fournisseur.dart';
+import '../../providers/fournisseur_providers.dart';
+import '../utils/fournisseur_list_utils.dart';
+
+/// Keys stables pour accessibilité et tests.
+const keyFournisseursSearch = Key('fournisseurs_search');
+const keyFournisseursSortToggle = Key('fournisseurs_sort_toggle');
+const keyFournisseursList = Key('fournisseurs_list');
+
+Key keyFournisseursRow(String id) => Key('fournisseurs_row_$id');
+
+/// Écran liste fournisseurs (Sprint 1 — lecture seule).
+/// Recherche client-side (nom, pays, contact_personne), tri nom A→Z / Z→A.
+class FournisseursListScreen extends ConsumerStatefulWidget {
+  const FournisseursListScreen({super.key});
+
+  @override
+  ConsumerState<FournisseursListScreen> createState() =>
+      _FournisseursListScreenState();
+}
+
+class _FournisseursListScreenState extends ConsumerState<FournisseursListScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  bool _sortAsc = true; // true = A→Z, false = Z→A
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController.addListener(_onSearchChanged);
+  }
+
+  void _onSearchChanged() {
+    final q = _searchController.text;
+    if (q != _searchQuery) setState(() => _searchQuery = q);
+  }
+
+  @override
+  void dispose() {
+    _searchController.removeListener(_onSearchChanged);
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  String _contact(Fournisseur f) {
+    if (f.email != null && f.email!.isNotEmpty) return f.email!;
+    if (f.telephone != null && f.telephone!.isNotEmpty) return f.telephone!;
+    return '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncList = ref.watch(fournisseursListProvider);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Fournisseurs'),
+        actions: [
+          Semantics(
+            button: true,
+            label: _sortAsc ? 'Tri A vers Z par nom' : 'Tri Z vers A par nom',
+            child: IconButton(
+              key: keyFournisseursSortToggle,
+              tooltip: _sortAsc ? 'Tri A→Z' : 'Tri Z→A',
+              icon: Icon(_sortAsc ? Icons.arrow_upward : Icons.arrow_downward),
+              onPressed: () => setState(() => _sortAsc = !_sortAsc),
+            ),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Semantics(
+              textField: true,
+              label: 'Rechercher par nom, pays ou contact',
+              hint: 'Rechercher (nom, pays, contact)',
+              child: TextField(
+                key: keyFournisseursSearch,
+                controller: _searchController,
+                decoration: InputDecoration(
+                  hintText: 'Rechercher (nom, pays, contact)',
+                  prefixIcon: const Icon(Icons.search),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  isDense: true,
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: asyncList.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (_, __) => _buildError(context),
+              data: (list) {
+                final filtered = filterFournisseurs(list, _searchQuery);
+                final sorted = sortFournisseursByNom(filtered, _sortAsc);
+                if (sorted.isEmpty) {
+                  return _buildEmpty(context, list.isEmpty);
+                }
+                return _buildList(context, sorted, theme);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildError(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 64,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Erreur lors du chargement',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: () => ref.refresh(fournisseursListProvider),
+              icon: const Icon(Icons.refresh),
+              label: const Text('Réessayer'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmpty(BuildContext context, bool noDataAtAll) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.business_outlined,
+              size: 64,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              noDataAtAll ? 'Aucun fournisseur' : 'Aucun fournisseur',
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Vérifie la recherche ou le référentiel DB.',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildList(
+    BuildContext context,
+    List<Fournisseur> list,
+    ThemeData theme,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: Text(
+            '${list.length} fournisseur(s)',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            key: keyFournisseursList,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            itemCount: list.length,
+            itemBuilder: (context, index) {
+              final f = list[index];
+              final contact = _contact(f);
+              final subtitle = [
+                if (f.pays != null && f.pays!.isNotEmpty) 'Pays: ${f.pays}',
+                if (contact.isNotEmpty) 'Contact: $contact',
+              ].join(' · ');
+              return Card(
+                margin: const EdgeInsets.only(bottom: 8),
+                child: ListTile(
+                  key: keyFournisseursRow(f.id),
+                  title: Text(f.nom),
+                  subtitle: subtitle.isEmpty ? null : Text(subtitle),
+                  isThreeLine: subtitle.length > 40,
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => context.go('/fournisseurs/${f.id}'),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/fournisseurs/presentation/utils/fournisseur_list_utils.dart
+++ b/lib/features/fournisseurs/presentation/utils/fournisseur_list_utils.dart
@@ -1,0 +1,41 @@
+// Filtre et tri client-side (fonctions pures, testables sans Supabase).
+
+import '../../domain/models/fournisseur.dart';
+
+/// Filtre client-side multi-champs (nom, pays, contact_personne).
+/// Case-insensitive, ignore nulls.
+List<Fournisseur> filterFournisseurs(
+  List<Fournisseur> list,
+  String query,
+) {
+  final q = query.trim().toLowerCase();
+  if (q.isEmpty) {
+    return List.from(list);
+  }
+  return list.where((f) {
+    if ((f.nom).toLowerCase().contains(q)) {
+      return true;
+    }
+    if (f.pays != null && (f.pays!).toLowerCase().contains(q)) {
+      return true;
+    }
+    if (f.contactPersonne != null &&
+        (f.contactPersonne!).toLowerCase().contains(q)) {
+      return true;
+    }
+    return false;
+  }).toList();
+}
+
+/// Tri client-side par nom uniquement. [asc] true = A→Z, false = Z→A.
+List<Fournisseur> sortFournisseursByNom(
+  List<Fournisseur> list,
+  bool asc,
+) {
+  final copy = List<Fournisseur>.from(list);
+  copy.sort((a, b) {
+    final cmp = (a.nom).compareTo(b.nom);
+    return asc ? cmp : -cmp;
+  });
+  return copy;
+}

--- a/lib/features/fournisseurs/providers/fournisseur_providers.dart
+++ b/lib/features/fournisseurs/providers/fournisseur_providers.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ml_pp_mvp/shared/providers/supabase_client_provider.dart';
+
+import '../data/repositories/supabase_fournisseur_repository.dart';
+import '../domain/models/fournisseur.dart';
+import '../domain/repositories/fournisseur_repository.dart';
+
+/// Repository injecté (Supabase client via provider existant).
+final fournisseurRepositoryProvider = Provider<FournisseurRepository>((ref) {
+  final client = ref.watch(supabaseClientProvider);
+  return SupabaseFournisseurRepository(client);
+});
+
+/// Liste complète des fournisseurs (AsyncValue<List<Fournisseur>>).
+final fournisseursListProvider =
+    FutureProvider.autoDispose<List<Fournisseur>>((ref) async {
+  final repo = ref.watch(fournisseurRepositoryProvider);
+  return repo.fetchAllFournisseurs();
+});
+
+/// Détail d'un fournisseur par id.
+final fournisseurDetailProvider =
+    FutureProvider.autoDispose.family<Fournisseur?, String>((ref, id) async {
+  final repo = ref.watch(fournisseurRepositoryProvider);
+  return repo.getById(id);
+});

--- a/test/features/fournisseurs/data/fournisseur_repository_test.dart
+++ b/test/features/fournisseurs/data/fournisseur_repository_test.dart
@@ -1,0 +1,68 @@
+// Module Fournisseurs — Tests unitaires repository (mock Supabase, pas Supabase.instance).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/data/repositories/supabase_fournisseur_repository.dart';
+import '../../../support/fakes/fake_supabase_query.dart';
+
+void main() {
+  group('SupabaseFournisseurRepository', () {
+    late FakeSupabaseClient fakeClient;
+    late SupabaseFournisseurRepository repo;
+
+    setUp(() {
+      fakeClient = FakeSupabaseClient();
+      repo = SupabaseFournisseurRepository(fakeClient);
+    });
+
+    test('fetchAllFournisseurs retourne la liste des fournisseurs', () async {
+      // Ordre seed : le fake ne trie pas, le repo attend déjà trié par la DB
+      fakeClient.setViewData('fournisseurs', [
+        {
+          'id': 'id-a',
+          'nom': 'Alpha',
+          'contact_personne': 'Contact A',
+          'email': null,
+          'telephone': null,
+          'adresse': null,
+          'pays': 'FR',
+          'note_supplementaire': null,
+          'created_at': '2026-01-02T12:00:00.000Z',
+        },
+        {
+          'id': 'id-b',
+          'nom': 'Beta',
+          'contact_personne': null,
+          'email': 'b@test.com',
+          'telephone': null,
+          'adresse': null,
+          'pays': 'CD',
+          'note_supplementaire': null,
+          'created_at': '2026-01-01T12:00:00.000Z',
+        },
+      ]);
+
+      final list = await repo.fetchAllFournisseurs();
+
+      expect(list.length, 2);
+      expect(list[0].nom, 'Alpha');
+      expect(list[0].pays, 'FR');
+      expect(list[0].contactPersonne, 'Contact A');
+      expect(list[1].nom, 'Beta');
+      expect(list[1].email, 'b@test.com');
+      expect(fakeClient.fromCalls, ['fournisseurs']);
+    });
+
+    test('fetchAllFournisseurs retourne liste vide si aucune donnée', () async {
+      fakeClient.setViewData('fournisseurs', []);
+
+      final list = await repo.fetchAllFournisseurs();
+
+      expect(list, isEmpty);
+    });
+
+    test('getById avec id vide retourne null', () async {
+      final one = await repo.getById('');
+      expect(one, isNull);
+    });
+  });
+}

--- a/test/features/fournisseurs/presentation/utils/fournisseur_list_utils_test.dart
+++ b/test/features/fournisseurs/presentation/utils/fournisseur_list_utils_test.dart
@@ -1,0 +1,76 @@
+// Filtre et tri fournisseurs — tests unitaires (fonctions pures, pas Supabase).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/domain/models/fournisseur.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/presentation/utils/fournisseur_list_utils.dart';
+
+void main() {
+  final list = [
+    const Fournisseur(
+      id: '1',
+      nom: 'Alpha',
+      pays: 'France',
+      contactPersonne: 'Alice',
+    ),
+    const Fournisseur(
+      id: '2',
+      nom: 'Beta',
+      pays: 'Belgique',
+      contactPersonne: 'Bob',
+    ),
+    const Fournisseur(
+      id: '3',
+      nom: 'Gamma',
+      pays: 'CD',
+      contactPersonne: 'Charlie',
+    ),
+  ];
+
+  group('filterFournisseurs', () {
+    test('query vide retourne toute la liste', () {
+      expect(filterFournisseurs(list, ''), list);
+      expect(filterFournisseurs(list, '   '), list);
+    });
+
+    test('filtre par nom (case-insensitive)', () {
+      expect(filterFournisseurs(list, 'alpha'), hasLength(1));
+      expect(filterFournisseurs(list, 'ALPHA')[0].nom, 'Alpha');
+      expect(filterFournisseurs(list, 'beta'), hasLength(1));
+    });
+
+    test('filtre par pays', () {
+      expect(filterFournisseurs(list, 'fran'), hasLength(1));
+      expect(filterFournisseurs(list, 'France')[0].nom, 'Alpha');
+      expect(filterFournisseurs(list, 'bel'), hasLength(1));
+      expect(filterFournisseurs(list, 'Belgique')[0].nom, 'Beta');
+    });
+
+    test('filtre par contact_personne', () {
+      expect(filterFournisseurs(list, 'Bob'), hasLength(1));
+      expect(filterFournisseurs(list, 'Charlie')[0].nom, 'Gamma');
+      expect(filterFournisseurs(list, 'alice'), hasLength(1));
+    });
+
+    test('aucun match retourne liste vide', () {
+      expect(filterFournisseurs(list, 'xyz'), isEmpty);
+    });
+  });
+
+  group('sortFournisseursByNom', () {
+    test('asc trie A→Z', () {
+      final sorted = sortFournisseursByNom(list, true);
+      expect(sorted.map((e) => e.nom).toList(), ['Alpha', 'Beta', 'Gamma']);
+    });
+
+    test('desc trie Z→A', () {
+      final sorted = sortFournisseursByNom(list, false);
+      expect(sorted.map((e) => e.nom).toList(), ['Gamma', 'Beta', 'Alpha']);
+    });
+
+    test('ne modifie pas la liste originale', () {
+      final copy = List<Fournisseur>.from(list);
+      sortFournisseursByNom(list, true);
+      expect(list, copy);
+    });
+  });
+}

--- a/test/features/fournisseurs/providers/fournisseur_providers_test.dart
+++ b/test/features/fournisseurs/providers/fournisseur_providers_test.dart
@@ -1,0 +1,121 @@
+// Module Fournisseurs — Tests providers (AsyncValue, pas Supabase.instance).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/domain/models/fournisseur.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/domain/repositories/fournisseur_repository.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/providers/fournisseur_providers.dart';
+
+/// Fake repository pour tests (aucune dépendance Supabase).
+class FakeFournisseurRepository implements FournisseurRepository {
+  final List<Fournisseur> _list;
+  final Fournisseur? _byId;
+
+  FakeFournisseurRepository({List<Fournisseur>? list, Fournisseur? byId})
+      : _list = list ?? [],
+        _byId = byId;
+
+  @override
+  Future<List<Fournisseur>> fetchAllFournisseurs() async => List.from(_list);
+
+  @override
+  Future<Fournisseur?> getById(String id) async => _byId;
+}
+
+void main() {
+  group('fournisseursListProvider', () {
+    test('loading puis data avec liste vide', () async {
+      final container = ProviderContainer(
+        overrides: [
+          fournisseurRepositoryProvider.overrideWithValue(
+            FakeFournisseurRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final list = await container.read(fournisseursListProvider.future);
+      expect(list, isEmpty);
+    });
+
+    test('AsyncValue data contient les fournisseurs', () async {
+      final seed = [
+        const Fournisseur(id: '1', nom: 'F1', pays: 'CD'),
+        const Fournisseur(id: '2', nom: 'F2', pays: 'FR'),
+      ];
+      final container = ProviderContainer(
+        overrides: [
+          fournisseurRepositoryProvider.overrideWithValue(
+            FakeFournisseurRepository(list: seed),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(fournisseursListProvider.future);
+      final asyncValue = container.read(fournisseursListProvider);
+      expect(asyncValue.hasValue, isTrue);
+      expect(asyncValue.value, hasLength(2));
+      expect(asyncValue.value![0].nom, 'F1');
+      expect(asyncValue.value![1].nom, 'F2');
+    });
+
+    test('override avec erreur : le future throw', () async {
+      final container = ProviderContainer(
+        overrides: [
+          fournisseurRepositoryProvider.overrideWithValue(
+            _ThrowingRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await expectLater(
+        container.read(fournisseursListProvider.future),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('fournisseurDetailProvider', () {
+    test('retourne null quand absent', () async {
+      final container = ProviderContainer(
+        overrides: [
+          fournisseurRepositoryProvider.overrideWithValue(
+            FakeFournisseurRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final f = await container.read(fournisseurDetailProvider('id-x').future);
+      expect(f, isNull);
+    });
+
+    test('retourne le fournisseur quand présent', () async {
+      const fourn = Fournisseur(id: 'id-1', nom: 'Détail F', pays: 'BE');
+      final container = ProviderContainer(
+        overrides: [
+          fournisseurRepositoryProvider.overrideWithValue(
+            FakeFournisseurRepository(byId: fourn),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final f = await container.read(fournisseurDetailProvider('id-1').future);
+      expect(f, isNotNull);
+      expect(f!.nom, 'Détail F');
+    });
+  });
+}
+
+class _ThrowingRepository implements FournisseurRepository {
+  @override
+  Future<List<Fournisseur>> fetchAllFournisseurs() async {
+    throw Exception('Test error');
+  }
+
+  @override
+  Future<Fournisseur?> getById(String id) async => null;
+}

--- a/test/features/fournisseurs/screens/fournisseur_detail_screen_test.dart
+++ b/test/features/fournisseurs/screens/fournisseur_detail_screen_test.dart
@@ -1,0 +1,47 @@
+// Module Fournisseurs — Widget test écran détail (sections, badge ACTIF, pas Supabase).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/domain/models/fournisseur.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/presentation/screens/fournisseur_detail_screen.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/providers/fournisseur_providers.dart';
+
+const _testId = 'detail-test-1';
+final _testFournisseur = Fournisseur(
+  id: _testId,
+  nom: 'Test Fournisseur',
+  pays: 'France',
+  contactPersonne: 'Jean Dupont',
+  email: 'jean@test.com',
+  telephone: '01 23 45 67 89',
+  adresse: '1 rue Example, 75001 Paris',
+  noteSupplementaire: 'Note test',
+  createdAt: DateTime(2026, 1, 15, 10, 30),
+);
+
+void main() {
+  group('FournisseurDetailScreen', () {
+    testWidgets('affiche sections Informations et Adresse et badge ACTIF',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fournisseurDetailProvider.overrideWith(
+              (ref, id) => Future.value(_testFournisseur),
+            ),
+          ],
+          child: const MaterialApp(
+            home: FournisseurDetailScreen(fournisseurId: _testId),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Informations'), findsOneWidget);
+      expect(find.text('Adresse'), findsOneWidget);
+      expect(find.text('ACTIF'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/fournisseurs/screens/fournisseurs_list_screen_test.dart
+++ b/test/features/fournisseurs/screens/fournisseurs_list_screen_test.dart
@@ -1,0 +1,247 @@
+// Module Fournisseurs — Widget tests écran liste (recherche, tri, Keys, navigation, pas Supabase).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/domain/models/fournisseur.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/presentation/screens/fournisseur_detail_screen.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/presentation/screens/fournisseurs_list_screen.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/providers/fournisseur_providers.dart';
+
+final _threeFournisseurs = [
+  const Fournisseur(
+    id: '1',
+    nom: 'Alpha',
+    pays: 'France',
+    contactPersonne: 'Alice',
+  ),
+  const Fournisseur(
+    id: '2',
+    nom: 'Beta',
+    pays: 'Belgique',
+    contactPersonne: 'Bob',
+  ),
+  const Fournisseur(
+    id: '3',
+    nom: 'Gamma',
+    pays: 'CD',
+    contactPersonne: 'Charlie',
+  ),
+];
+
+void main() {
+  group('FournisseursListScreen', () {
+    testWidgets('affiche le titre Fournisseurs', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fournisseursListProvider.overrideWith(
+                (ref) => Future.value(<Fournisseur>[])),
+          ],
+          child: const MaterialApp(
+            home: FournisseursListScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Fournisseurs'), findsOneWidget);
+    });
+
+    testWidgets('build sans erreur avec liste vide', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fournisseursListProvider.overrideWith(
+                (ref) => Future.value(<Fournisseur>[])),
+          ],
+          child: const MaterialApp(
+            home: FournisseursListScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Fournisseurs'), findsOneWidget);
+    });
+
+    testWidgets('empty state affiche message et aide', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fournisseursListProvider.overrideWith(
+                (ref) => Future.value(<Fournisseur>[])),
+          ],
+          child: const MaterialApp(
+            home: FournisseursListScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Aucun fournisseur'), findsOneWidget);
+      expect(find.text('Vérifie la recherche ou le référentiel DB.'), findsOneWidget);
+    });
+
+    testWidgets('présente les Keys search, sort, list et row', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fournisseursListProvider.overrideWith(
+                (ref) => Future.value(_threeFournisseurs)),
+          ],
+          child: const MaterialApp(
+            home: FournisseursListScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(keyFournisseursSearch), findsOneWidget);
+      expect(find.byKey(keyFournisseursSortToggle), findsOneWidget);
+      expect(find.byKey(keyFournisseursList), findsOneWidget);
+      expect(find.byKey(keyFournisseursRow('1')), findsOneWidget);
+      expect(find.byKey(keyFournisseursRow('2')), findsOneWidget);
+      expect(find.byKey(keyFournisseursRow('3')), findsOneWidget);
+    });
+
+    testWidgets('build sans erreur avec données', (tester) async {
+      final list = [
+        const Fournisseur(id: '1', nom: 'Fournisseur A', pays: 'FR'),
+        const Fournisseur(id: '2', nom: 'Fournisseur B', pays: 'CD'),
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fournisseursListProvider.overrideWith((ref) => Future.value(list)),
+          ],
+          child: const MaterialApp(
+            home: FournisseursListScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Fournisseur A'), findsOneWidget);
+      expect(find.text('Fournisseur B'), findsOneWidget);
+    });
+
+    testWidgets('recherche filtre par pays et contact_personne', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fournisseursListProvider.overrideWith(
+                (ref) => Future.value(_threeFournisseurs)),
+          ],
+          child: const MaterialApp(
+            home: FournisseursListScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
+      expect(find.text('Gamma'), findsOneWidget);
+
+      await tester.enterText(find.byKey(keyFournisseursSearch), 'Belgique');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Beta'), findsOneWidget);
+      expect(find.text('Alpha'), findsNothing);
+      expect(find.text('Gamma'), findsNothing);
+
+      await tester.enterText(find.byKey(keyFournisseursSearch), 'Charlie');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Gamma'), findsOneWidget);
+      expect(find.text('Alpha'), findsNothing);
+      expect(find.text('Beta'), findsNothing);
+    });
+
+    testWidgets('tri toggle inverse l\'ordre par nom', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fournisseursListProvider.overrideWith(
+                (ref) => Future.value(_threeFournisseurs)),
+          ],
+          child: const MaterialApp(
+            home: FournisseursListScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final listTiles = find.byType(ListTile);
+      expect(listTiles, findsNWidgets(3));
+      expect((tester.widgetList(listTiles).first as ListTile).title, isA<Text>());
+      expect(((tester.widgetList(listTiles).first as ListTile).title as Text).data, 'Alpha');
+
+      await tester.tap(find.byKey(keyFournisseursSortToggle));
+      await tester.pumpAndSettle();
+
+      expect((tester.widgetList(listTiles).first as ListTile).title, isA<Text>());
+      expect(((tester.widgetList(listTiles).first as ListTile).title as Text).data, 'Gamma');
+    });
+
+    testWidgets('tap fournisseur row navigue vers détail', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/fournisseurs',
+        routes: [
+          GoRoute(
+            path: '/fournisseurs',
+            builder: (_, __) => const FournisseursListScreen(),
+          ),
+          GoRoute(
+            path: '/fournisseurs/:id',
+            builder: (_, state) {
+              final id = state.pathParameters['id']!;
+              return FournisseurDetailScreen(fournisseurId: id);
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            fournisseursListProvider.overrideWith(
+                (ref) => Future.value(_threeFournisseurs)),
+            fournisseurDetailProvider.overrideWith((ref, id) {
+              Fournisseur? found;
+              for (final f in _threeFournisseurs) {
+                if (f.id == id) {
+                  found = f;
+                  break;
+                }
+              }
+              return Future.value(found);
+            }),
+          ],
+          child: MaterialApp.router(
+            routerConfig: router,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(keyFournisseursRow('1')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FournisseurDetailScreen), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Ajoute le module Fournisseurs (lecture seule) basé sur public.fournisseurs
Recherche client-side (nom/pays/contact_personne) + tri toggle nom
UI liste + détail + empty states + Keys testables
Tests : repo/providers/utils/screens + navigation tap
✅ Aucun changement DB / triggers / RLS
✅ Aucun impact flux PROD : CDR → Réception → Stock → Sortie
✅ flutter test test/features/fournisseurs/ -r expanded ✅ (sur la branche PR)