### PR TITLE
feat(nav): add Fournisseurs menu entry (role-gated) after Cours de route

### DIFF
--- a/lib/shared/navigation/app_router.dart
+++ b/lib/shared/navigation/app_router.dart
@@ -29,6 +29,9 @@ import 'package:ml_pp_mvp/features/logs/screens/logs_list_screen.dart';
 import 'package:ml_pp_mvp/features/citernes/screens/citerne_list_screen.dart';
 import 'package:ml_pp_mvp/features/stocks/screens/stocks_screen.dart';
 import 'package:ml_pp_mvp/features/stocks_adjustments/screens/stocks_adjustments_list_screen.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/presentation/screens/fournisseurs_list_screen.dart';
+import 'package:ml_pp_mvp/features/fournisseurs/presentation/screens/fournisseur_detail_screen.dart';
+import 'package:ml_pp_mvp/shared/navigation/nav_config.dart';
 
 // Default home page for authenticated users
 const String kDefaultHome = '/receptions';
@@ -201,6 +204,17 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             builder: (ctx, st) => const CiterneListScreen(),
           ),
           GoRoute(path: '/stocks', builder: (ctx, st) => const StocksScreen()),
+          GoRoute(
+            path: '/fournisseurs',
+            builder: (ctx, st) => const FournisseursListScreen(),
+          ),
+          GoRoute(
+            path: '/fournisseurs/:id',
+            builder: (ctx, st) {
+              final id = st.pathParameters['id']!;
+              return FournisseurDetailScreen(fournisseurId: id);
+            },
+          ),
           GoRoute(path: '/logs', builder: (ctx, st) => const LogsListScreen()),
           GoRoute(
             path: '/stocks-adjustments',
@@ -237,6 +251,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       // 3) Connecté + rôle prêt : normalisation
       if (loc.isEmpty || loc == '/' || loc == '/login' || loc == '/dashboard') {
         return role.dashboardPath; // ton getter existant
+      }
+
+      // 4) Fournisseurs : accès réservé admin / directeur / gérant / pca
+      if (loc.startsWith('/fournisseurs') && !kFournisseurRoles.contains(role)) {
+        return role.dashboardPath;
       }
 
       return null; // rien à faire

--- a/lib/shared/navigation/nav_config.dart
+++ b/lib/shared/navigation/nav_config.dart
@@ -20,6 +20,14 @@ const kAllRoles = <UserRole>[
   UserRole.lecture, // <- déjà présent mais on centralise
 ];
 
+// Rôles autorisés pour le module Fournisseurs (admin, directeur, gérant, pca)
+const kFournisseurRoles = <UserRole>[
+  UserRole.admin,
+  UserRole.directeur,
+  UserRole.gerant,
+  UserRole.pca,
+];
+
 class NavItem {
   final String id;
   final String title;
@@ -98,12 +106,20 @@ class NavConfig {
       order: 5,
     ),
     NavItem(
+      id: 'fournisseurs',
+      title: 'Fournisseurs',
+      path: '/fournisseurs',
+      icon: Icons.business_outlined,
+      allowedRoles: kFournisseurRoles,
+      order: 6,
+    ),
+    NavItem(
       id: 'logs',
       title: 'Logs / Audit',
       path: '/logs',
       icon: Icons.list_alt_outlined,
       allowedRoles: kAllRoles,
-      order: 6,
+      order: 7,
     ),
     NavItem(
       id: 'stocks-adjustments',
@@ -111,7 +127,7 @@ class NavConfig {
       path: '/stocks-adjustments',
       icon: Icons.tune_outlined,
       allowedRoles: kAllRoles,
-      order: 7,
+      order: 8,
     ),
   ];
 


### PR DESCRIPTION
- Add NavItem /fournisseurs visible only to admin/directeur/gerant/pca
- Register routes /fournisseurs and /fournisseurs/:id
- Add router guard redirecting unauthorized roles to dashboard
- No DB changes; no impact on core PROD flows
