### PR TITLE
docs(post-prod): architecture fonctionnelle + roadmap + requirements v1

### DIFF
--- a/docs/POST_PROD/00_OVERVIEW.md
+++ b/docs/POST_PROD/00_OVERVIEW.md
@@ -1,0 +1,30 @@
+# POST-PROD — Overview
+
+## Contexte
+ML_PP (Monaluxe Petrol Platform) est en PROD EN EXPLOITATION depuis le 2026-02-05.
+Le socle logistique est validé et ne doit pas être modifié.
+
+## Règle absolue
+Toute évolution doit être classée dans une catégorie POST-PROD :
+- MAINTENANCE
+- AUDIT
+- SCALE
+- POST-PROD FEATURE
+
+## Invariants intouchables
+- Flux métier : CDR → Réception → Stock → Sortie
+- Source de vérité stock : v_stock_actuel
+- RLS + triggers (sécurité & métier)
+- IDs produits canoniques
+- Aucun reset PROD
+- Aucune suppression destructive (vues, triggers, RLS, contrats)
+
+## Principe POST-PROD
+Le POST-PROD ajoute des modules **au-dessus** du socle existant.
+Aucune fonctionnalité post-prod ne doit "mélanger" finance/contrats avec les écrans opérationnels.
+
+## Objectif POST-PROD
+Faire évoluer ML_PP vers une plateforme ERP pétrolière modulaire :
+- Logistique (socle existant)
+- Contractuel & financier (nouveaux modules)
+- Contrôle (écarts, litiges, audit)

--- a/docs/POST_PROD/01_ARCHITECTURE_FONCTIONNELLE_GLOBALE.md
+++ b/docs/POST_PROD/01_ARCHITECTURE_FONCTIONNELLE_GLOBALE.md
@@ -1,0 +1,79 @@
+# POST-PROD — Architecture Fonctionnelle Globale (v1)
+
+## 1. Objectif
+Définir la structure fonctionnelle globale du POST-PROD afin de transformer ML_PP
+en ERP pétrolier spécialisé, sans modifier le socle opérationnel existant.
+
+---
+
+## 2. Socle opérationnel (intouchable)
+Le flux suivant reste strictement inchangé :
+CDR → Réception → Stock → Sortie
+
+Source de vérité stock : v_stock_actuel
+
+---
+
+## 3. Domaines Fonctionnels
+
+### DOMAINE 1 — OPERATIONS (déjà en PROD)
+- Cours de Route (CDR)
+- Réceptions
+- Sorties
+- Stock
+- Citernes
+
+Ce domaine est stable et validé.
+
+---
+
+### DOMAINE 2 — PROCUREMENT (Fournisseurs / AP)
+Chaîne documentaire :
+SBLC → Proforma → CDR → Réceptions → Facture Finale → Paiements → Relevé fournisseur
+
+Objectif :
+Gérer l'engagement fournisseur jusqu'au paiement complet, avec gestion des écarts Proforma vs Réceptions.
+
+---
+
+### DOMAINE 3 — SALES (Clients / AR)
+Chaîne documentaire :
+Sortie → Livraison → Facture client → Encaissement → Relevé client
+
+Objectif :
+Suivre les ventes et les créances clients, avec gestion des écarts Sortie vs Livraison (si applicable).
+
+---
+
+### DOMAINE 4 — LOGISTICS (Transporteurs)
+Chaîne documentaire :
+Mission → Livraison → Avance → Paiement → Relevé transporteur
+
+Objectif :
+Tracer les coûts logistiques, avances, paiements et soldes transporteurs.
+
+---
+
+### DOMAINE 5 — CONTROL & AUDIT
+- Module Écarts & Anomalies (centre unique)
+- Litiges
+- Ajustements
+- Journal avancé
+- Reporting direction
+
+Objectif :
+Maîtriser les différences volumes et financières, et assurer une traçabilité opposable.
+
+---
+
+## 4. Principes clés
+1. Séparation stricte Opérations / Finance
+2. Traçabilité complète des documents
+3. Gestion explicite des écarts via un module central (pas de logique dispersée)
+4. Préparation multi-organisation (future-ready)
+
+---
+
+## 5. Navigation (règle simple)
+Navigation principale par domaines :
+Dashboard → Opérations → Stock → Partenaires → Finances → Rapports → Administration

--- a/docs/POST_PROD/02_ROADMAP_POST_PROD.md
+++ b/docs/POST_PROD/02_ROADMAP_POST_PROD.md
@@ -1,0 +1,117 @@
+# POST-PROD — Roadmap (v1)
+
+## 1. Objectif
+Séquençer les travaux POST-PROD afin de construire une plateforme ERP pétrolière
+(logistique + contractuel + financier + contrôle) sans impacter le socle PROD.
+
+## 2. Principes (non négociables)
+- Le socle Opérations reste inchangé : CDR → Réception → Stock → Sortie
+- Stock actuel : v_stock_actuel (contrat)
+- RLS + triggers intacts
+- IDs produits canoniques intacts
+- Toute évolution = MAINTENANCE / AUDIT / SCALE / POST-PROD FEATURE
+
+---
+
+## 3. Phasage recommandé
+
+### PHASE 0 — Préparation (Documentation & Cadre)
+**Livrables**
+- POST_PROD/00_OVERVIEW.md
+- POST_PROD/01_ARCHITECTURE_FONCTIONNELLE_GLOBALE.md
+- POST_PROD/INDEX.md
+
+**Critères d'acceptation**
+- Documentation relue et validée
+- Le périmètre POST-PROD est clair (modules, objectifs, non-objectifs)
+
+---
+
+### PHASE 1 — PROCUREMENT (Fournisseurs / AP)
+**Objectif**
+Mettre en place la chaîne fournisseur complète :
+SBLC → Proforma → CDR → Réceptions → Facture Finale → Paiements → Relevé fournisseur
+
+**Jalons**
+1) SBLC (garantie)
+2) Proforma (source des CDR)
+3) Liaison Proforma → génération/association CDR
+4) Facture Finale (basée sur réceptions réelles)
+5) Paiements (total / partiel, allocation)
+6) Relevé fournisseur (solde & échéances)
+
+**Critères d'acceptation**
+- Un fournisseur peut avoir plusieurs SBLC (banques différentes)
+- Une proforma peut générer plusieurs CDR (camions)
+- Les réceptions réelles alimentent la consolidation facture finale
+- Les paiements partiels sont supportés (reste dû calculé)
+- Un relevé fournisseur affiche : solde, factures ouvertes, paiements, échéances
+
+**Non-objectifs (phase 1)**
+- Comptabilité générale complète
+- Tarification avancée multi-conditions
+- Gestion fiscale (TVA/impôts) complexe
+
+---
+
+### PHASE 2 — ÉCARTS & ANOMALIES (centre unique)
+**Objectif**
+Tracer, expliquer et traiter les différences volumétriques et financières.
+
+**Types d'écarts**
+1) Proforma vs Réception (fournisseur)
+2) Volume sorti/chargé vs volume livré client
+3) Écarts transporteurs (pertes, litiges, ajustements)
+
+**Critères d'acceptation**
+- Un écran unique liste les écarts (filtrable par période, entité, statut)
+- Chaque écart possède : cause, pièces jointes/notes, statut, responsable
+- Statuts : OUVERT → EN_COURS → RÉSOLU (minimum)
+- L'écart peut aboutir à : litige, ajustement document, avoir, note explicative
+
+---
+
+### PHASE 3 — SALES (Clients / AR)
+**Objectif**
+Gérer la vente : livraisons → factures → encaissements → relevé client.
+
+**Jalons**
+1) Livraisons client (liées aux sorties)
+2) Factures client (basées sur livraisons)
+3) Encaissements (total / partiel, allocation)
+4) Relevé client
+
+**Critères d'acceptation**
+- Une sortie peut être associée à une livraison client
+- Factures émises depuis livraisons confirmées
+- Encaissements partiels supportés
+- Relevé client : solde, factures ouvertes, paiements, échéances
+
+---
+
+### PHASE 4 — TRANSPORTEURS
+**Objectif**
+Gérer les prestataires logistiques mandatés par Monaluxe.
+
+**Jalons**
+1) Missions / courses (liées aux livraisons)
+2) Avances (avant mission)
+3) Décompte & paiement (après mission)
+4) Relevé transporteur
+
+**Critères d'acceptation**
+- Avances et paiements tracés par mission
+- Solde transporteur calculable (avances vs dû)
+- Liens visibles entre livraisons, missions et paiements
+
+---
+
+## 4. Dépendances (ordre logique)
+- Phase 1 (Procurement) avant Phase 3 (Sales) recommandée
+- Phase 2 (Écarts) peut démarrer dès Phase 1 (au moins pour Proforma vs Réceptions)
+- Phase 4 (Transporteurs) dépend de la structuration des livraisons (Phase 3)
+
+---
+
+## 5. Prochain document à écrire
+- 03 — Procurement (spécifications détaillées SBLC / Proforma / Facture finale / Paiements / Relevé)

--- a/docs/POST_PROD/03_PROCUREMENT_REQUIREMENTS.md
+++ b/docs/POST_PROD/03_PROCUREMENT_REQUIREMENTS.md
@@ -1,0 +1,189 @@
+# POST-PROD — Procurement (Fournisseurs / AP) — Requirements (v1)
+
+## 1. Objectif
+Mettre en place le module **Procurement** pour gérer la chaîne fournisseur complète :
+
+SBLC (garantie) → Proforma → CDR → Réceptions → Facture Finale → Paiements → Relevé fournisseur
+
+Le module Procurement doit :
+- Structurer les engagements fournisseurs (avant livraison)
+- Consolider les quantités réellement reçues
+- Gérer la facturation réelle et les paiements (total/partiel)
+- Exposer un relevé fournisseur (solde + échéances)
+- Tracer les écarts (proforma vs réceptions) de manière explicite
+
+---
+
+## 2. Invariants (socle PROD)
+- Flux immuable : CDR → Réception → Stock → Sortie
+- Stock actuel : v_stock_actuel
+- RLS + triggers intacts
+- IDs produits canoniques intacts
+- Aucun reset PROD, aucune suppression destructive
+
+---
+
+## 3. Concepts & définitions
+
+### 3.1 SBLC (Standby Letter of Credit)
+Garantie en faveur d'un fournisseur, utilisée uniquement en cas de non-paiement.
+Règles :
+- Une SBLC est associée à **un fournisseur** (bénéficiaire).
+- Un fournisseur peut avoir **plusieurs SBLC** (banques différentes).
+- Une SBLC a : montant, devise, dates de validité, statut (ACTIVE/EXPIRED/CLOSED).
+
+### 3.2 Proforma
+Document émis par le fournisseur.
+Rôle : base de génération des CDR (camions attendus).
+Règles :
+- Une proforma contient une ou plusieurs lignes produit (produit, quantité prévue, prix unitaire, devise).
+- Une proforma peut générer **plusieurs CDR**.
+- La proforma est une "prévision" : les quantités réelles viennent des réceptions.
+
+### 3.3 Facture Finale (réelle)
+Document final basé sur les volumes réellement réceptionnés.
+Règles :
+- Elle se base sur un ensemble de réceptions (liées à des CDR associés à la proforma).
+- Elle supporte : ajustements, avoirs, litiges.
+- Elle supporte les paiements partiels.
+- Elle possède une date facture et une échéance (due_date).
+
+### 3.4 Paiement fournisseur
+Règlement bancaire réalisé par Monaluxe.
+Règles :
+- Un paiement peut couvrir une facture totale ou partielle.
+- Un paiement peut être alloué à une ou plusieurs factures (option v2) ; en v1, on peut limiter à 1 facture si nécessaire.
+- Traçabilité obligatoire : date, montant, devise, référence bancaire.
+
+### 3.5 Relevé fournisseur
+Vue consolidée montrant ce que Monaluxe doit au fournisseur (ou l'inverse).
+Affiche :
+- Solde courant
+- Factures ouvertes / échéances
+- Paiements effectués
+- Avoirs / ajustements
+
+---
+
+## 4. Workflow cible (vue métier)
+
+### 4.1 Création SBLC
+1) Créer SBLC (fournisseur, banque, montant, devise, validité)
+2) Activer SBLC
+3) Suivre expirations (alertes post-v1)
+
+### 4.2 Création Proforma
+1) Créer proforma (fournisseur, période, devise, conditions)
+2) Ajouter lignes produits
+3) Valider proforma
+4) Générer/associer les CDR attendus
+
+### 4.3 Réceptions (déjà en PROD)
+- Les réceptions se font comme aujourd'hui (socle inchangé)
+- Elles sont liées aux CDR, et donc indirectement à la proforma
+
+### 4.4 Génération Facture Finale
+1) Sélectionner une proforma
+2) Système liste toutes les réceptions réelles liées aux CDR de cette proforma
+3) Calculer : quantités réelles par produit + montant
+4) Détecter écarts (proforma vs réel)
+5) Créer la facture finale
+6) Valider la facture finale
+
+### 4.5 Paiement facture
+v1 : un paiement est obligatoirement lié à une seule facture finale. Le paiement se crée depuis l'écran de la facture.
+1) Enregistrer paiement (montant/devise/date/ref)
+2) Affecter à la facture (v1 : une facture)
+3) Mettre à jour statut facture : PARTIALLY_PAID ou PAID
+4) Relevé fournisseur mis à jour automatiquement
+
+---
+
+## 5. Gestion des écarts (obligatoire)
+Le module Procurement doit produire des écarts :
+- Quantité proforma vs quantité réceptionnée (par produit)
+- Valeur proforma vs valeur facturée réelle
+- Écart de prix (si applicable)
+
+Traitement v1 :
+- afficher l'écart dans le détail proforma et facture finale
+- possibilité de "marquer comme accepté" avec note
+- sinon "ouvrir un litige" (connecté au futur module Écarts & Anomalies)
+
+---
+
+## 6. Statuts (v1)
+### SBLC
+- DRAFT
+- ACTIVE
+- EXPIRED
+- CLOSED
+
+### Proforma
+- DRAFT
+- VALIDATED
+- CLOSED
+
+Une proforma peut passer CLOSED quand tous les CDR associés sont DECHARGE et qu'une facture finale est VALIDATED (ou créée selon décision).
+
+### Facture Finale
+- DRAFT
+- VALIDATED
+- PARTIALLY_PAID
+- PAID
+- DISPUTED
+- CANCELLED
+
+### Paiement
+- RECORDED
+- CANCELLED (rare, admin)
+
+### Numérotation (v1)
+SBLC, Proforma, Facture Finale et Paiement disposent chacun d'une numérotation dédiée (préfixe + année + séquence, format à définir).
+
+---
+
+## 7. Permissions (v1)
+- OPERATEUR : lecture proforma/factures, pas de validation ni paiement
+- GERANT / DIRECTEUR : valider proforma + valider facture finale
+- FINANCE : enregistrer paiements + consulter relevés
+- PCA / LECTURE : lecture globale
+- ADMIN : tout
+
+---
+
+## 8. UX (écrans minimum v1)
+### Fournisseur (fiche 360°)
+Onglets :
+- Proformas
+- Factures finales
+- Paiements
+- Relevé
+- SBLC
+
+### Écrans dédiés
+- Liste SBLC + détail
+- Liste Proformas + détail (avec CDR associés)
+- Liste Factures finales + détail (avec réceptions consolidées)
+- Paiements (création + historique)
+- Relevé fournisseur (filtrable par période)
+
+---
+
+## 9. Critères d'acceptation (v1)
+- Créer une SBLC pour un fournisseur et la marquer ACTIVE
+- Créer une proforma avec lignes produits et la valider
+- Associer/générer des CDR depuis proforma (au minimum lien)
+- Consolider les réceptions liées pour produire une facture finale
+- Enregistrer un paiement partiel et voir le reste dû
+- Voir un relevé fournisseur cohérent (solde + factures ouvertes + paiements)
+- Les écarts proforma vs réel sont visibles dans proforma et facture finale
+
+---
+
+## 10. Non-objectifs (v1)
+- Comptabilité générale complète
+- Multi-devise avancée (taux, conversion automatique)
+- Allocation paiement multi-factures (si on le repousse en v2)
+- Gestion fiscale avancée (TVA/impôts)
+- Notifications/alertes (post-v1)

--- a/docs/POST_PROD/04_SALES_CLIENTS_AR_REQUIREMENTS.md
+++ b/docs/POST_PROD/04_SALES_CLIENTS_AR_REQUIREMENTS.md
@@ -1,0 +1,155 @@
+# POST-PROD — Sales (Clients / AR) — Requirements (v1)
+
+## 1. Objectif
+Mettre en place le module **Sales / Clients (AR)** pour gérer :
+- les **bons de livraison (BL)** émis pour les clients,
+- les **factures clients** basées sur les livraisons,
+- les **encaissements** (paiements reçus) total/partiel,
+- le **relevé client** (solde + échéances),
+- la traçabilité des écarts **Sortie vs Livraison** via le module Écarts.
+
+Chaîne documentaire :
+**Sortie (stock) → Bon de Livraison (BL) → Facture Client → Encaissement → Relevé client**
+
+---
+
+## 2. Invariants (socle PROD)
+- Flux immuable : CDR → Réception → Stock → Sortie
+- Stock actuel : v_stock_actuel
+- RLS + triggers intacts
+- IDs produits canoniques intacts
+- Aucun reset PROD, aucune suppression destructive
+
+---
+
+## 3. Concepts & définitions
+
+### 3.1 Sortie (stock)
+Événement opérationnel qui décrémente le stock (déjà en PROD).
+La sortie peut alimenter une ou plusieurs livraisons (cas exceptionnel) mais v1 : 1 sortie → 1 BL.
+
+### 3.2 Bon de Livraison (BL)
+Document de livraison remis au client (preuve).
+Règles v1 :
+- Un BL est associé à un client.
+- Un BL est associé à une sortie (référence obligatoire).
+- Un BL contient les volumes livrés (ambiant + 15°C si disponible).
+- Un BL peut être **confirmé** (signature / validation) pour être facturable.
+
+### 3.3 Facture client
+Document commercial basé sur un ou plusieurs BL confirmés.
+Règles v1 :
+- v1 : 1 facture = 1..n BL (plusieurs BL confirmés)
+- Une facture ne peut inclure que des BL du même client
+- Un BL ne peut appartenir qu'à une seule facture
+- Support paiements partiels (reste à payer)
+
+### 3.4 Encaissement
+Paiement reçu du client.
+Règles v1 :
+- v1 : 1 encaissement est lié à une facture
+- un encaissement peut être partiel
+- une facture calcule reste à payer
+- Traçabilité : date, montant, devise, référence (cash/banque)
+
+### 3.5 Relevé client
+Vue consolidée :
+- solde client
+- factures ouvertes
+- paiements reçus
+- échéances
+
+---
+
+## 4. Workflow cible (v1)
+
+### 4.1 Création BL depuis une sortie
+1) L'utilisateur sélectionne une sortie validée
+2) Crée un BL (client, date, destinataire, chauffeur/plaque si utile)
+3) Saisit volumes livrés
+4) Statut BL = DRAFT
+5) Confirme BL → statut CONFIRMED
+
+### 4.2 Gestion des écarts Sortie vs Livraison
+À confirmation BL :
+- calculer delta (sortie vs volumes BL)
+- si delta ≠ 0 : créer un écart dans le module Écarts & Anomalies
+- l'écart doit référencer : SORTIE + LIVRAISON
+
+### 4.3 Facturation
+1) Créer facture à partir d'un ou plusieurs BL CONFIRMED (sélection multi-BL confirmés du même client)
+2) Calculer montant (prix unitaire, devise)
+3) Statut facture = DRAFT
+4) Valider facture → VALIDATED
+5) Verrouiller BL une fois facturé
+
+### 4.4 Encaissement
+1) Enregistrer paiement reçu (montant, date, ref)
+2) Affecter à facture (v1 : une facture)
+3) Statut facture : PARTIALLY_PAID ou PAID
+4) Relevé client mis à jour
+
+---
+
+## 5. Statuts (v1)
+
+### BL
+- DRAFT
+- CONFIRMED
+- CANCELLED
+
+### Facture client
+- DRAFT
+- VALIDATED
+- PARTIALLY_PAID
+- PAID
+- DISPUTED
+- CANCELLED
+
+### Encaissement
+- RECORDED
+- CANCELLED (admin)
+
+---
+
+## 6. Permissions (v1)
+- OPERATEUR : créer BL, confirmer BL
+- GERANT/DIRECTEUR : valider facture, gérer litiges
+- FINANCE : enregistrer encaissements, consulter relevés
+- PCA/LECTURE : lecture seule
+- ADMIN : tout
+
+---
+
+## 7. UX (écrans minimum v1)
+
+### 7.1 Client (fiche 360°)
+Onglets :
+- Livraisons (BL)
+- Factures
+- Encaissements
+- Relevé
+
+### 7.2 Écrans dédiés
+- Liste BL + détail (avec sortie liée)
+- Liste Factures client + détail
+- Encaissements (création + historique)
+- Relevé client (filtrable)
+
+---
+
+## 8. Critères d'acceptation (v1)
+- Créer un BL depuis une sortie validée
+- Confirmer un BL
+- Générer automatiquement un écart si volumes BL ≠ volumes sortie
+- Créer une facture à partir de plusieurs BL confirmés (même client)
+- Enregistrer un encaissement partiel et voir le reste dû
+- Relevé client : solde cohérent, factures ouvertes, paiements
+
+---
+
+## 9. Non-objectifs (v1)
+- Multi-BL par sortie (v2)
+- Gestion fiscale avancée (TVA etc.)
+- Tarification complexe / remises / contrats (post-v1)
+- Notifications automatiques (post-v1)

--- a/docs/POST_PROD/05_TRANSPORTEURS_REQUIREMENTS.md
+++ b/docs/POST_PROD/05_TRANSPORTEURS_REQUIREMENTS.md
@@ -1,0 +1,167 @@
+# POST-PROD — Transporteurs — Requirements (v1)
+
+## 1. Objectif
+Mettre en place le module **Transporteurs** pour gérer :
+- les transporteurs utilisés par Monaluxe pour livrer chez les clients,
+- les **missions** (courses) associées aux livraisons (BL),
+- les **avances** versées avant/pendant mission,
+- les **décomptes** (montant dû final),
+- les **paiements** (total/partiel),
+- le **relevé transporteur** (solde).
+
+Chaîne documentaire cible :
+**Bon de Livraison (BL) → Mission → Avances → Décompte → Paiements → Relevé transporteur**
+
+---
+
+## 2. Invariants (socle PROD)
+- Flux immuable : CDR → Réception → Stock → Sortie
+- Stock actuel : v_stock_actuel
+- RLS + triggers intacts
+- IDs produits canoniques intacts
+- Aucun reset PROD, aucune suppression destructive
+
+---
+
+## 3. Concepts & définitions
+
+### 3.1 Transporteur
+Entité partenaire logistique (peut avoir plusieurs chauffeurs/camions).
+V1 : gestion simple (identité, contacts, notes, statut actif/inactif).
+
+### 3.2 Mission (course)
+Document qui représente une prestation de transport réalisée par un transporteur.
+Règles v1 :
+- Une mission est liée à **un transporteur**
+- Une mission est liée à **1..n BL** (souvent groupés par tournée)
+- Une mission a un statut et une période (date départ, date arrivée)
+- Une mission peut avoir un montant dû (décompte) après exécution
+
+### 3.3 Avance transporteur
+Paiement anticipé (cash/virement) avant la fin de mission.
+Règles v1 :
+- Une avance est liée à une mission
+- Une mission peut avoir plusieurs avances
+- Traçabilité : date, montant, devise, référence
+
+### 3.4 Décompte
+Montant final à payer pour la mission (après livraison).
+Règles v1 :
+- Le décompte est lié à une mission
+- Il peut intégrer : montant brut, retenues, pénalités (v2), ajustements
+- V1 : un seul montant final simple
+
+### 3.5 Paiement transporteur
+Paiement effectué au transporteur pour apurer tout ou partie du décompte.
+Règles v1 :
+- Paiements partiels possibles
+- 1 paiement lié à une mission (v1)
+
+Calcul v1 (règle officielle) :
+- total_avances = somme(avances RECORDED)
+- total_paiements = somme(paiements RECORDED)
+- reste_a_payer = montant_decompte - total_avances - total_paiements
+- si reste_a_payer < 0 : trop-perçu (crédit transporteur)
+
+Note v1 : les avances restent une catégorie distincte pour le terrain, mais elles sont déduites automatiquement du décompte dans le calcul du reste à payer.
+
+### 3.6 Relevé transporteur
+Vue consolidée montrant :
+- missions
+- avances
+- décomptes
+- paiements
+- solde (dû ou trop-perçu)
+
+---
+
+## 4. Workflow cible (v1)
+
+### 4.1 Création mission depuis des BL
+1) Sélectionner un transporteur
+2) Sélectionner 1..n BL CONFIRMED (même transporteur/tournée)
+3) Créer mission (dates, chauffeur/plaque si utile)
+4) Statut = DRAFT
+
+### 4.2 Exécution mission
+- Mission passe IN_PROGRESS quand départ effectif
+- Mission passe DELIVERED quand toutes les livraisons sont confirmées (BL)
+
+### 4.3 Avances
+- Ajouter une ou plusieurs avances pendant la mission
+- Avances visibles dans le détail mission
+
+### 4.4 Décompte et paiements
+1) Créer décompte (montant final dû)
+2) Enregistrer paiements (total/partiel)
+3) Statut mission : SETTLED quand reste à payer = 0
+
+---
+
+## 5. Statuts (v1)
+
+### Mission
+- DRAFT
+- IN_PROGRESS
+- DELIVERED
+- SETTLED
+- CANCELLED
+
+### Avance
+- RECORDED
+- CANCELLED (admin)
+
+### Décompte
+- DRAFT
+- VALIDATED
+- CANCELLED (admin)
+
+### Paiement transporteur
+- RECORDED
+- CANCELLED (admin)
+
+---
+
+## 6. Permissions (v1)
+- OPERATEUR : créer mission, ajouter avances, passer DELIVERED (si autorisé)
+- GERANT/DIRECTEUR : valider décompte, clôturer mission SETTLED
+- FINANCE : enregistrer paiements, consulter relevés
+- PCA/LECTURE : lecture seule
+- ADMIN : tout
+
+---
+
+## 7. UX (écrans minimum v1)
+
+### 7.1 Transporteur (fiche 360°)
+Onglets :
+- Missions
+- Avances
+- Décomptes
+- Paiements
+- Relevé
+
+### 7.2 Écrans dédiés
+- Liste missions + détail (avec BL liés)
+- Ajout avance (dans mission)
+- Décompte (dans mission)
+- Paiements (dans mission)
+- Relevé transporteur (filtrable)
+
+---
+
+## 8. Critères d'acceptation (v1)
+- Créer une mission et y associer plusieurs BL confirmés
+- Enregistrer une avance sur mission
+- Créer un décompte et le valider
+- Enregistrer un paiement partiel et voir le reste à payer
+- Mission passe SETTLED quand reste à payer = 0
+- Relevé transporteur cohérent (missions, avances, paiements, solde)
+
+---
+
+## 9. Non-objectifs (v1)
+- Tarification automatique par km/zone
+- SLA, pénalités automatiques, incidents détaillés
+- Paiement multi-missions (v2)
+- Gestion avancée des chauffeurs/vehicules (post-v1)

--- a/docs/POST_PROD/06_ECARTS_ANOMALIES_REQUIREMENTS.md
+++ b/docs/POST_PROD/06_ECARTS_ANOMALIES_REQUIREMENTS.md
@@ -1,0 +1,202 @@
+# POST-PROD — Écarts & Anomalies (v1) — Requirements
+
+## 1. Objectif
+Créer un module central **Écarts & Anomalies** qui :
+- détecte et trace les différences (volumes, montants, documents),
+- permet le traitement (analyse, justification, décision),
+- alimente audit, reporting, et futurs litiges.
+
+Le module doit couvrir au minimum :
+1) Proforma vs Réception réelle (fournisseur)
+2) Sortie/chargé vs Livré client (transport/livraison)
+3) Écarts transporteurs (pertes, litiges, ajustements)
+
+---
+
+## 2. Invariants (socle PROD)
+- Flux immuable : CDR → Réception → Stock → Sortie
+- Stock actuel : v_stock_actuel
+- RLS + triggers intacts
+- IDs produits canoniques intacts
+- Aucun reset PROD, aucune suppression destructive
+
+---
+
+## 3. Définitions
+### 3.1 Écart
+Différence mesurable entre :
+- une **référence attendue** (prévision, document source)
+- et une **réalité constatée** (réception, livraison, facture réelle)
+
+Un écart doit être traçable, justifiable, et clôturable.
+
+### 3.2 Anomalie
+Événement irrégulier ou incohérent (données manquantes, incohérence de statuts, doublons),
+pouvant générer un écart ou nécessiter investigation.
+
+---
+
+## 4. Types d'écarts (v1)
+
+### 4.1 Fournisseur — Proforma vs Réception
+**Source attendue** : Proforma (quantités prévues, prix)
+**Réel** : Réceptions liées aux CDR de la proforma
+
+Écarts calculés :
+- écart volume (par produit)
+- écart valeur (si prix applicable)
+- écart nombre de camions (si pertinent)
+
+### 4.2 Client — Sortie/chargé vs Livraison
+**Attendu** : Volume sorti (chargé) depuis les citernes
+**Réel** : Volume livré client (confirmé)
+
+Écarts calculés :
+- écart volume ambiant + volume 15°C (si disponible)
+- différence par livraison / par client
+
+### 4.3 Transporteur — Sortie/Livraison vs Mission
+**Attendu** : Mission et conditions transport
+**Réel** : Livraison + confirmations + incidents
+
+Écarts calculés :
+- pertes / manquants
+- retards / incidents (option v2)
+- litiges (si contesté)
+
+---
+
+## 5. Cycle de vie (workflow) — v1
+
+### Statuts
+- OPEN (créé / détecté)
+- IN_REVIEW (analyse en cours)
+- RESOLVED (clos avec décision)
+- DISPUTED (litige ouvert, si nécessaire)
+
+### Règle
+Un écart ne disparaît jamais :
+il passe à un statut final avec justification et auteur.
+
+### Règles de transition
+- OPEN → IN_REVIEW : note optionnelle
+- IN_REVIEW → RESOLVED : cause + décision + note obligatoire
+- IN_REVIEW → DISPUTED : note obligatoire
+- RESOLVED/DISPUTED : non modifiables sauf admin
+
+---
+
+## 6. Création des écarts (détection)
+Deux modes v1 :
+
+### 6.1 Automatique (recommandé)
+Création automatique lorsqu'un document "réel" est validé :
+- À validation facture finale : écarts Proforma vs Réceptions (si delta ≠ 0)
+- À confirmation livraison : écart Sortie vs Livraison (si delta ≠ 0)
+
+### 6.2 Manuel (obligatoire)
+Un utilisateur autorisé peut créer un écart manuellement si :
+- données incomplètes
+- incident terrain
+- contestation
+
+---
+
+## 7. Références & traçabilité (v1)
+Chaque écart doit référencer au minimum :
+- **reference_type** : PROFORMA / FACTURE_FINALE / RECEPTION / SORTIE / LIVRAISON / MISSION
+- **reference_id**
+
+Optionnel : secondary_reference_type / secondary_reference_id (ex. facture finale liée à proforma).
+
+---
+
+## 8. Traitement d'un écart (actions v1)
+La clôture RESOLVED exige une note justifiant la décision.
+Sur un écart, l'utilisateur peut :
+
+1) **Ajouter une note**
+2) **Ajouter une pièce justificative** (lien / référence, v1 simple)
+3) **Classer une cause** (liste contrôlée)
+4) **Proposer une décision**
+5) **Clôturer**
+
+### Causes (v1 — liste simple)
+- PERTE_TRANSPORT
+- ERREUR_SAISIE
+- DIFFERENCE_TEMPERATURE_DENSITE
+- MANQUANT_FOURNISSEUR
+- LIVRAISON_PARTIELLE
+- AUTRE
+
+### Décisions (v1)
+- ACCEPTE_AVEC_NOTE (on accepte l'écart)
+- AJUSTEMENT_REQUIS (un ajustement document/stock sera fait via module dédié)
+- LITIGE (passer DISPUTED)
+- ANNULER (rare, admin)
+
+---
+
+## 9. Permissions (v1)
+- OPERATEUR : créer écart manuel, ajouter note, passer en IN_REVIEW
+- GERANT/DIRECTEUR : clôturer RESOLVED, marquer litige DISPUTED
+- FINANCE : consulter + traiter les écarts liés aux factures/paiements
+- PCA/LECTURE : lecture seule
+- ADMIN : tout (dont ANNULER)
+
+---
+
+## 10. UX (écrans minimum v1)
+
+### 10.1 Écran Liste (centre unique)
+Filtres :
+- période
+- type (fournisseur/client/transporteur)
+- statut
+- entité (fournisseur/client/transporteur)
+- produit (si applicable)
+
+Colonnes :
+- date
+- type
+- entité
+- référence (proforma / facture / livraison)
+- delta volume
+- delta valeur (si applicable)
+- statut
+- owner (responsable)
+
+### 10.2 Détail écart
+Sections :
+- Résumé (type, références, delta)
+- Historique (notes, changements statut)
+- Pièces (v1 : liens)
+- Actions (changer statut, clôturer)
+
+---
+
+## 11. Reporting (v1)
+KPI minimum :
+- nombre d'écarts OPEN
+- top causes
+- volume total en écart (par produit)
+- écarts par fournisseur / client / transporteur
+
+---
+
+## 12. Critères d'acceptation (v1)
+- Un écart Proforma vs Réception est créé automatiquement quand delta ≠ 0
+- Un écart Sortie vs Livraison est créable manuellement (et automatiquement si livraison confirmée existe)
+- La liste affiche filtres + statuts
+- Un écart peut être passé OPEN → IN_REVIEW → RESOLVED avec note obligatoire
+- Un écart peut être marqué DISPUTED
+- Lecture seule pour PCA/LECTURE
+- Historique consultable sur le détail
+
+---
+
+## 13. Non-objectifs (v1)
+- Gestion documentaire complète (uploads, OCR)
+- Workflow d'approbation multi-niveaux complexe
+- SLA / pénalités automatiques
+- Notifications automatiques (post-v1)

--- a/docs/POST_PROD/07_REPORTING_AUDIT_REQUIREMENTS.md
+++ b/docs/POST_PROD/07_REPORTING_AUDIT_REQUIREMENTS.md
@@ -1,0 +1,162 @@
+# POST-PROD — Reporting & Audit (v1) — Requirements
+
+## 1. Objectif
+Créer un module **Reporting & Audit** pour donner une vision direction/finance,
+sans impacter le socle opérationnel, et avec traçabilité opposable.
+
+Le module doit permettre :
+- KPIs Procurement (AP) : reste à payer fournisseurs
+- KPIs Sales (AR) : reste à encaisser clients
+- KPIs Transporteurs : soldes, avances, reste à payer
+- KPIs Écarts : volume/valeur en écart, causes, statuts
+- Exports (PDF/Excel) v1
+- Journal/Audit : qui a fait quoi, quand, sur quel document
+
+---
+
+## 2. Invariants (socle PROD)
+- Flux immuable : CDR → Réception → Stock → Sortie
+- Stock actuel : v_stock_actuel
+- RLS + triggers intacts
+- IDs produits canoniques intacts
+- Aucun reset PROD, aucune suppression destructive
+
+---
+
+## 3. Public cible
+- PCA / Direction : lecture globale, KPIs, exports
+- Finance : suivi AR/AP, encaissements/paiements, contrôles
+- Gérant / Directeur : pilotage opérationnel + anomalies
+- Admin : tout
+
+---
+
+## 4. Périmètre v1
+
+### 4.1 Dashboards (v1)
+1) Dashboard Finance
+2) Dashboard Direction
+3) Dashboard Audit/Contrôle
+
+### 4.2 KPIs minimum (v1)
+
+#### A) Fournisseurs (AP)
+- Total factures finales VALIDATED
+- Total payé
+- Total reste à payer
+- Répartition par fournisseur
+- Factures en retard (échéance dépassée)
+
+#### B) Clients (AR)
+- Total factures VALIDATED
+- Total encaissé
+- Total reste à encaisser
+- Répartition par client
+- Factures en retard (échéance dépassée)
+
+#### C) Transporteurs
+- Total décomptes VALIDATED
+- Total avances
+- Total payé
+- Total reste à payer
+- Transporteurs en trop-perçu (crédit transporteur)
+
+#### D) Écarts & Anomalies
+- Nombre d'écarts OPEN / IN_REVIEW / DISPUTED
+- Volume total en écart (par produit)
+- Top causes
+- Écarts par fournisseur / client / transporteur
+
+---
+
+## 5. Dimensions & filtres (communs)
+Tous les écrans KPI doivent offrir :
+- période (date_from, date_to)
+- entité (fournisseur / client / transporteur)
+- statut (facture/paiement/écart)
+- produit (si applicable)
+- dépôt (si applicable)
+- export des résultats filtrés
+
+---
+
+## 6. Exports (v1)
+Exports nécessaires :
+- Relevé fournisseur (PDF/Excel)
+- Relevé client (PDF/Excel)
+- Relevé transporteur (PDF/Excel)
+- Listing écarts (Excel)
+- KPIs (Excel)
+
+V1 : export "simple" (tableaux + totaux), sans mise en page complexe.
+
+---
+
+## 7. Audit & traçabilité (v1)
+Exigences :
+- Toute création/validation/annulation d'un document post-prod est loggée :
+  - qui (user)
+  - quoi (type document)
+  - action (create/validate/cancel/pay/collect/close)
+  - quand (timestamp)
+  - référence (id)
+- Les exports doivent inclure :
+  - période
+  - filtre appliqué
+  - date génération
+  - utilisateur générateur
+
+---
+
+## 8. Permissions (v1)
+- OPERATEUR : lecture limitée (aucun export global)
+- GERANT/DIRECTEUR : accès dashboards + exports opérationnels
+- FINANCE : accès AR/AP + exports
+- PCA/LECTURE : lecture globale + exports
+- ADMIN : tout
+
+---
+
+## 9. UX (écrans minimum v1)
+
+### 9.1 Reporting Home
+Cartes :
+- AP (fournisseurs)
+- AR (clients)
+- Transporteurs
+- Écarts
+- Exports
+
+### 9.2 Écrans KPI
+- Graphiques simples (option)
+- Table filtrable
+- Totaux en header
+- Bouton Export
+
+### 9.3 Journal Audit
+Table :
+- date
+- user
+- action
+- type document
+- référence
+- commentaire (si disponible)
+
+---
+
+## 10. Critères d'acceptation (v1)
+- Voir une page Reporting avec cartes AP/AR/Transporteurs/Écarts
+- Filtrer par période et entité
+- Afficher totaux + détail
+- Exporter un relevé fournisseur, client, transporteur
+- Exporter listing écarts
+- Journal audit consultable et filtrable
+- Les exports contiennent métadonnées (filtres + date + user)
+
+---
+
+## 11. Non-objectifs (v1)
+- BI avancé (drill-down multi-niveaux)
+- Alertes automatiques (post-v1)
+- Exports "mise en page officielle" complexe (post-v1)
+- Connexion à un outil comptable externe (post-v1)

--- a/docs/POST_PROD/08_NAVIGATION_POST_PROD.md
+++ b/docs/POST_PROD/08_NAVIGATION_POST_PROD.md
@@ -1,0 +1,115 @@
+# POST-PROD — Navigation Fonctionnelle (v1)
+
+## 1. Objectif
+Définir une navigation claire, modulaire et user-friendly
+pour intégrer les modules POST-PROD sans complexifier l'interface.
+
+Navigation maximum : 2 niveaux.
+
+---
+
+# 2. Structure principale (Sidebar / NavigationRail)
+
+## SECTION 1 — OPÉRATIONS (existant, inchangé)
+- Dashboard
+- Cours de Route
+- Réceptions
+- Sorties
+- Stock
+- Citernes
+
+---
+
+## SECTION 2 — COMMERCIAL
+
+### Clients
+- Bons de Livraison (BL)
+- Factures clients
+- Encaissements
+- Relevé client
+
+---
+
+## SECTION 3 — FOURNISSEURS (Procurement)
+
+### Fournisseurs
+- SBLC
+- Proformas
+- Factures finales
+- Paiements
+- Relevé fournisseur
+
+---
+
+## SECTION 4 — LOGISTIQUE
+
+### Transporteurs
+- Missions
+- Avances
+- Décomptes
+- Paiements
+- Relevé transporteur
+
+---
+
+## SECTION 5 — CONTRÔLE
+
+- Écarts & Anomalies
+- Reporting & Audit
+
+---
+
+# 3. Accès transversal
+
+## Depuis une fiche :
+- Fournisseur → voir ses écarts
+- Client → voir ses écarts
+- Transporteur → voir ses écarts
+- Facture → voir paiements
+- Mission → voir avances/décompte
+
+Bouton standard : "Voir écarts liés"
+
+---
+
+# 4. Navigation par rôle
+
+## OPERATEUR
+- Opérations
+- BL
+- Missions
+- Écarts (création / suivi)
+
+## FINANCE
+- Fournisseurs
+- Clients
+- Transporteurs
+- Reporting
+
+## GERANT / DIRECTEUR
+- Accès complet
+- Reporting global
+
+## PCA
+- Lecture seule
+- Reporting complet
+
+---
+
+# 5. Règles UX clés
+
+1. Une entité = une fiche 360° (avec onglets)
+2. Pas plus de 2 niveaux de profondeur
+3. Les écarts ne sont jamais cachés
+4. Les soldes (reste à payer / encaisser) sont visibles en badge
+5. Les statuts sont affichés par couleur
+
+---
+
+# 6. Évolution future (v2+)
+
+- Douanes / Import
+- Contrats clients
+- Contrats transporteurs
+- Multi-organisation
+- Intégration comptable

--- a/docs/POST_PROD/INDEX.md
+++ b/docs/POST_PROD/INDEX.md
@@ -1,0 +1,19 @@
+# POST-PROD — Index
+
+## 0. Point d'entrée
+- [00 — Overview](00_OVERVIEW.md)
+
+## 1. Architecture
+- [01 — Architecture Fonctionnelle Globale](01_ARCHITECTURE_FONCTIONNELLE_GLOBALE.md)
+
+## 2. Planning
+- [02 — Roadmap](02_ROADMAP_POST_PROD.md)
+
+## 3. Modules
+- [03 — Procurement (Requirements)](03_PROCUREMENT_REQUIREMENTS.md)
+- [04 — Sales (Clients / AR) — Requirements](04_SALES_CLIENTS_AR_REQUIREMENTS.md)
+- [05 — Transporteurs — Requirements](05_TRANSPORTEURS_REQUIREMENTS.md)
+- [06 — Écarts & Anomalies (Requirements)](06_ECARTS_ANOMALIES_REQUIREMENTS.md)
+- [07 — Reporting & Audit — Requirements](07_REPORTING_AUDIT_REQUIREMENTS.md)
+
+## 4. À venir


### PR DESCRIPTION
Ajout du répertoire docs/POST_PROD/ (v1)
Documentation POST-PROD only (non destructive)
Contenu :
Overview + Architecture fonctionnelle globale
Roadmap POST-PROD
Requirements v1 : Procurement, Sales/AR, Transporteurs, Écarts, Reporting/Audit
Navigation fonctionnelle v1
Aucun changement code / DB / triggers / RLS
Respect des invariants PROD (CDR → Réception → Stock → Sortie, v_stock_actuel, IDs canoniques)