### PR TITLE
feat(monitoring): Phase 1 UptimeRobot + Sentry (runbook + alerts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 
 ### Infra
 - Suppression usage dotenv en PROD Web
+- docs: add monitoring & alerting runbook (UptimeRobot + Sentry Phase 1)
 - Passage officiel à injection via `--dart-define`
 - Standardisation build Web avec SUPABASE_URL + SUPABASE_ANON_KEY
 - Validation déploiement Firebase Hosting

--- a/docs/02_RUNBOOKS/MONITORING_ALERTING.md
+++ b/docs/02_RUNBOOKS/MONITORING_ALERTING.md
@@ -1,0 +1,97 @@
+# Runbook — Monitoring & Alerting (ML_PP)
+
+## Objectif (règle des 2 minutes)
+Pouvoir répondre en moins de 2 minutes à :
+- La PROD est-elle UP ?
+- Si non, pourquoi ?
+- Depuis quand ?
+- Est-ce un incident technique ou un incident métier ?
+- Qui doit agir ?
+
+## Périmètre
+Phase 1 = "Niveau 0 + Niveau 1"
+- Niveau 0 : disponibilité (site web)
+- Niveau 1 : erreurs applicatives front (Flutter Web)
+
+Les niveaux suivants (métier, backend/sécurité) sont planifiés mais pas encore déployés.
+
+---
+
+## ✅ État actuel — Implémenté
+
+### Niveau 0 — Disponibilité (UptimeRobot)
+- Monitor: HTTP(s) sur https://monaluxe.app
+- Intervalle: 5 minutes (limite version gratuite)
+- Résultat attendu: alerte si HTTP != 200 / timeout / downtime.
+
+**Test effectué**
+- ✅ A2 (test uptime): alerte reçue.
+
+**Limites connues**
+- Pas de "SSL expiry checks" / "domain expiry reminders" en free.
+- Pas de "smoke endpoint" dédié (on surveille la home/SPA).
+
+---
+
+### Niveau 1 — Erreurs applicatives (Sentry)
+- Produit: Sentry
+- Intégration: sentry_flutter (Flutter Web)
+- Configuration via --dart-define
+  - SENTRY_DSN
+  - APP_ENV (ex: production / staging)
+  - APP_RELEASE (ex: mlpp-web)
+
+**Règles d'alerting configurées**
+1) Rule #1 — New issue created
+- Trigger: "A new issue is created"
+- IF: tag environment == production
+- THEN: notification aux membres/assignees configurés
+- Action interval: 24h
+
+2) Rule #2 — Spike d'événements (anti "incident silencieux")
+- Trigger: "Number of events in an issue is more than 10 in 5 minutes"
+- + (optionnel/présent selon configuration): "A new issue is created"
+- IF: tag environment == production
+- THEN: notification (Suggested Assignees, fallback All Project Members)
+- Action interval: 24h
+
+**Tests effectués**
+- ✅ B2 (test notification Sentry): alerte reçue.
+
+---
+
+## Procédures (opérationnel)
+
+### Si UptimeRobot alerte "DOWN"
+1) Confirmer rapidement depuis un navigateur externe (4G si possible)
+2) Vérifier Firebase Hosting (statut domaine / dernières releases)
+3) Vérifier Supabase (status page + latence API si suspicion)
+4) Si impact confirmé : déclencher incident interne + appliquer runbook rollback (si disponible)
+
+### Si Sentry alerte "New issue" ou "Spike"
+1) Ouvrir l'Issue Sentry → "Stack Trace" + "Tags"
+2) Identifier:
+- environment (production/staging)
+- release
+- browser.name
+3) Classer:
+- Erreur bloquante (login, dashboard, réception, sortie)
+- Erreur non bloquante (noise / plugin / navigateur)
+4) Action:
+- Mitigation immédiate si possible (feature flag / revert / hotfix)
+- Sinon: créer ticket correctif et prioriser
+
+---
+
+## Checkpoints & validation
+- ✅ A2 (test uptime) : OK
+- ✅ B2 (test notification Sentry) : OK
+- ✅ C (doc runbook ajouté) : OK
+
+---
+
+## Next (Phase 2 — à planifier)
+Niveau 2 (métier):
+- invariants SQL: stock négatif, snapshot absent, mélange propriétaire, sorties incohérentes, CDR bloqués, etc.
+Niveau 3 (backend/sécurité):
+- 401/403 spikes (RLS), 5xx, requêtes lentes, rate limiting, etc.

--- a/docs/POST_PROD/08_MONITORING_ALERTING.md
+++ b/docs/POST_PROD/08_MONITORING_ALERTING.md
@@ -1,0 +1,26 @@
+# POST-PROD — Monitoring & Alerting (Industriel)
+
+## But
+Mettre en place une surveillance "industrielle" progressive, sans surdimensionner l'outillage.
+
+## Phase 1 — Déployée
+### Niveau 0 — Uptime
+- UptimeRobot : monitor HTTP sur https://monaluxe.app (5 min)
+- Alerte opérationnelle reçue lors du test.
+
+### Niveau 1 — Observabilité erreurs front
+- Sentry : collecte erreurs Flutter Web
+- Règles d'alerte:
+  - New Issue (env=production)
+  - Spike > 10 events / 5 min (env=production)
+- Notification testée et validée.
+
+## Gouvernance
+- Ce qui compte: réduire le "temps de découverte" (TTD) et le "temps de mitigation" (TTM)
+- Référence opérationnelle: runbook
+  - [docs/02_RUNBOOKS/MONITORING_ALERTING.md](../02_RUNBOOKS/MONITORING_ALERTING.md)
+
+## À faire ensuite (Phase 2)
+- Monitoring métier (invariants SQL)
+- Monitoring backend/sécurité (RLS/5xx/latence)
+- Mini "cockpit santé" interne (option post Phase 2)

--- a/docs/POST_PROD/INDEX.md
+++ b/docs/POST_PROD/INDEX.md
@@ -15,5 +15,6 @@
 - [05 — Transporteurs — Requirements](05_TRANSPORTEURS_REQUIREMENTS.md)
 - [06 — Écarts & Anomalies (Requirements)](06_ECARTS_ANOMALIES_REQUIREMENTS.md)
 - [07 — Reporting & Audit — Requirements](07_REPORTING_AUDIT_REQUIREMENTS.md)
+- [08 — Monitoring & Alerting (Industriel)](08_MONITORING_ALERTING.md)
 
 ## 4. À venir

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -583,6 +583,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -751,6 +767,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  sentry:
+    dependency: transitive
+    description:
+      name: sentry
+      sha256: "599701ca0693a74da361bc780b0752e1abc98226cf5095f6b069648116c896bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.14.2"
+  sentry_flutter:
+    dependency: "direct main"
+    description:
+      name: sentry_flutter
+      sha256: "5ba2cf40646a77d113b37a07bd69f61bb3ec8a73cbabe5537b05a7c89d2656f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.14.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1140,6 +1172,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.23.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   json_annotation: ^4.9.0
   meta: ^1.11.0
 
+  sentry_flutter: ^8.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Description (copier-coller)
✅ UptimeRobot HTTP monitor : https://monaluxe.app (interval 5 min, notifications testées)
✅ Sentry Flutter : DSN via --dart-define=SENTRY_DSN=... (STAGING validé en local)
✅ Fix bootstrap Sentry : handler async + capture exception (réduction bruit “zone mismatch”)
✅ Alert rules Sentry : règle 1 (new issue) + règle 2 (burst/rate)
✅ Docs : runbook + index post-prod mis à jour + changelog
Checklist
 A2 test uptime : ✅
 B2 test notification Sentry : ✅
 C doc runbook ajouté : ✅
2) Tag “fin Phase 1”
Dans docs/POST_PROD/08_MONITORING_ALERTING.md, ajoute un petit bloc “✅ Phase 1 validée” (si pas déjà fait) :
date/heure
urls monitor
règle 1 + règle 2
commande flutter run -d chrome ... utilisée