### PR TITLE
docs(post-prod): RLS hardening (remove public policies) + fix ANON exposure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 
 ## [Unreleased]
 
+### ✨ Phase 2 — Governance ACK/RESOLVE Workflow (Feb 2026)
+
+#### Added
+- Alert lifecycle states: OPEN / ACK / RESOLVED
+- Role-gated mutations (admin/directeur only) sur écran Integrity Checks
+- Trigger `system_alerts_set_actor` pour auto-fill acknowledged_at, acknowledged_by, resolved_at, resolved_by
+- Boutons ACK / RESOLVE dans l'écran Governance Integrity
+
+#### Changed
+- Integrity Checks UI mise à jour avec boutons de cycle de vie
+- Écran Governance enrichi (source: `public.system_alerts` au lieu de `v_integrity_checks`)
+
+#### Known Issues
+- `acknowledged_by` pas systématiquement renseigné
+- UI ne rafraîchit pas toujours l'état de l'alerte après mutation
+- Policy RLS : devrait comparer `user_id` au lieu de `id`
+
+---
+
+### 🔒 Security / Governance — RLS Hardening (Feb 2026)
+- **Audit RLS** : Table-by-table audit revealed policies with `roles = {public}` (including dangerous `SELECT true`) → possible exposure via ANON REST (front embeds ANON key).
+- **Protocol** : STAGING-first (fix + validate), then PROD (audit + fix). One action at a time; curl ANON tests to prove exposure/closure. No data-destructive changes — RLS policies only (DROP/CREATE).
+- **STAGING** : Dropped/migrated all `{public}` policies; migrated 14 conditional policies to `{authenticated}` (profils, cours_de_route, prises_de_hauteur, sorties_produit, stocks_journaliers). Final: `count(public policies) = 0`.
+- **PROD** : Fixed critical leaks — dropped `read stocks_journaliers` and `read citernes` (both `{public} SELECT true`). Migrated remaining `{public}` → `{authenticated}`. Final: `count(public policies) = 0`; curl ANON on `stocks_journaliers` and `citernes` returns `[]`.
+- **Docs** : `docs/POST_PROD/RUNBOOK_RLS_HARDENING.md`, `12_PHASE2_PROD_DEPLOY_LOG.md` (RLS entry), Phase 2 Tracker Action 7 → DONE, standard "0 public policies" in strategy/plan.
+
+---
+
 ## 2026-02-19 — Phase 2 Integrity Observability (PR #71)
 
 ### Added

--- a/docs/POST_PROD/00_OVERVIEW.md
+++ b/docs/POST_PROD/00_OVERVIEW.md
@@ -2,7 +2,10 @@
 
 ## Contexte
 ML_PP (Monaluxe Petrol Platform) est en PROD EN EXPLOITATION depuis le 2026-02-05.
+URL active : https://monaluxe.app
 Le socle logistique est validé et ne doit pas être modifié.
+
+**Dernière évolution majeure (Feb 2026)** : Phase 2 Action 2 — Governance Integrity avec cycle de vie des alertes (OPEN → ACK → RESOLVED), table `public.system_alerts`, UI enrichie. Dette technique documentée dans `docs/POST_PROD/PHASE2_TECH_DEBT.md`.
 
 ## Règle absolue
 Toute évolution doit être classée dans une catégorie POST-PROD :
@@ -28,3 +31,11 @@ Faire évoluer ML_PP vers une plateforme ERP pétrolière modulaire :
 - Logistique (socle existant)
 - Contractuel & financier (nouveaux modules)
 - Contrôle (écarts, litiges, audit)
+
+---
+
+## RLS Hardening — Feb 2026
+
+- **Constat** : Audit RLS a révélé des policies `roles = {public}` (dont `SELECT true`) → exposition possible via ANON REST (clé ANON embarquée dans le front Flutter Web).
+- **Résultat** : STAGING et PROD durcis — **0 policy `{public}`** restante. Fuites critiques corrigées (ex. `stocks_journaliers`, `citernes`). Toute policy cible désormais `authenticated` (ou rôles explicites) avec conditions.
+- **Docs** : `docs/POST_PROD/RUNBOOK_RLS_HARDENING.md`, `12_PHASE2_PROD_DEPLOY_LOG.md` (Entry 2). Standard post-prod : **aucune policy publique** ; revue obligatoire pour toute nouvelle policy.

--- a/docs/POST_PROD/09_PHASE2_STRATEGIE.md
+++ b/docs/POST_PROD/09_PHASE2_STRATEGIE.md
@@ -98,3 +98,9 @@ La Phase 2 est validée comme priorité post-PROD. Exécution progressive, docum
 - **Contrats DB** : Aucune modification destructive des schémas, vues ou RLS existants sans validation formelle. Les ajouts (nouvelles tables, vues) sont autorisés tant qu’ils ne cassent pas les contrats en place.
 - **Tests** : Aucune suppression de tests. Les ajouts de tests sont encouragés.
 - **Déploiement** : Le script officiel `tools/release_web_prod.sh` et le runbook `docs/02_RUNBOOKS/DEPLOY_WEB_PROD_RUNBOOK.md` restent la référence.
+
+## Standard sécurité RLS — 0 policy publique (Feb 2026)
+
+- **Décision** : Aucune policy RLS ne doit avoir `roles = {public}`. Toute policy doit cibler `authenticated` (ou rôles explicites) avec une condition métier ou technique (jamais `SELECT true` pour public).
+- **Raison** : La clé ANON est exposée dans le front (Flutter Web). Une policy `{public}` avec `SELECT true` permet l'accès en lecture (voire écriture) sans authentification via REST.
+- **Revue** : Toute nouvelle migration ou modification RLS doit être revue pour ne pas réintroduire de policy `public`. Un check automatique (CI ou script) est recommandé pour bloquer la réintroduction de policies `{public}` (voir `docs/POST_PROD/RUNBOOK_RLS_HARDENING.md`).

--- a/docs/POST_PROD/10_PHASE2_PLAN_10_ACTIONS.md
+++ b/docs/POST_PROD/10_PHASE2_PLAN_10_ACTIONS.md
@@ -103,16 +103,16 @@
 
 ---
 
-## Action 7 — Audit RLS complet (DOC uniquement)
+## Action 7 — Audit RLS complet + Hardening (0 public policies) ✅ DONE
 
 | Élément | Détail |
 |---------|--------|
-| **Objectif** | Documenter l’audit RLS de toutes les tables sensibles : politiques par rôle, revue des trous, recommandations |
-| **Livrables doc** | Fichier `docs/db/security/AUDIT_RLS_COMPLET.md` ou mise à jour de `docs/db/policies.md` |
-| **Livrables tech** | Aucun (DOC uniquement à ce stade) |
-| **Owner** | [À assigner] |
-| **Dépendances** | Aucune |
-| **Done** | Audit documenté et validé |
+| **Statut** | DONE (2026-02-21) |
+| **Objectif** | Documenter l’audit RLS de toutes les tables sensibles : éliminer toute policy `{public}` (notamment `SELECT true`) pour supprimer l'exposition via ANON REST |
+| **Livrables doc** | `docs/POST_PROD/RUNBOOK_RLS_HARDENING.md` ; Entry 2 dans `12_PHASE2_PROD_DEPLOY_LOG.md` ; standard "0 public policies" dans stratégie/plan. |
+| **Livrables tech** | RLS uniquement : DROP/migration policies (STAGING puis PROD). Aucune mutation de données. |
+| **Résultat** | STAGING et PROD : `count(public policies) = 0`. Fuites ANON corrigées (ex. stocks_journaliers, citernes). |
+| **Done** | Audit exécuté ; hardening appliqué ; runbook et déploiement log à jour. |
 
 ---
 

--- a/docs/POST_PROD/11_PHASE2_TRACKER.md
+++ b/docs/POST_PROD/11_PHASE2_TRACKER.md
@@ -9,12 +9,12 @@
 | ID | Action | Axe | Priorité | Statut | Owner | PR/Commit | Date début | Date fin | Notes |
 |----|--------|-----|----------|--------|-------|-----------|------------|----------|-------|
 | 1 | Vue SQL v_integrity_checks | 1 | P1 | DONE (STAGING + PROD) | — | — | — | — | voir Evidence ci-dessous |
-| 2 | Table system_alerts (persistence + workflow) | 1 | P1 | TODO | — | — | — | — | Patch 2.1 (DOC+SQL STAGING) → 2.2 (sync job) → 2.3 (UI workflow) |
+| 2 | Table system_alerts (persistence + workflow) | 1 | P1 | DONE (PROD) | — | — | — | — | Patch 2.1→2.4 déployés. Dette technique documentée (PHASE2_TECH_DEBT.md). |
 | 3 | Job périodique d'évaluation (DOC) | 1 | P1 | TODO | — | — | — | — | |
 | 4 | Écran intégrité système | 1 | P2 | DONE (DOC + IMPLEMENTATION) | — | PR #71 / 9a80413 | 2026-02-19 | 2026-02-19 | UI livrée, tests OK |
 | 5 | Standardiser APP_ENV & APP_RELEASE (DOC) | 2 | P1 | TODO | — | — | — | — | |
 | 6 | Endpoint /health + 2e monitor uptime (DOC) | 2 | P2 | TODO | — | — | — | — | |
-| 7 | Audit RLS complet (DOC) | 3 | P1 | TODO | — | — | — | — | |
+| 7 | Audit RLS complet + hardening (0 public policies) | 3 | P1 | DONE | — | docs(post-prod) | 2026-02-21 | 2026-02-21 | Runbook + deploy log Entry 2 |
 | 8 | Journal accès suspect (DOC) | 3 | P2 | TODO | — | — | — | — | |
 | 9 | Hash release visible UI (DOC) | 4 | P2 | TODO | — | — | — | — | |
 | 10 | Runbook rollback web (DOC) | 4 | P1 | TODO | — | — | — | — | |
@@ -28,16 +28,14 @@
 - **Risk** : Low
 - **Rollback** : `DROP VIEW public.v_integrity_checks`
 - **Validation STAGING** : 1 alerte CDR_ARRIVE_STALE pertinente, 0 bruit sur STOCK_NEGATIF / STOCK_OVER_CAPACITY / RECEPTION_ECART_15C / SORTIE_ECART_15C.
-- **Next** : Action 2 (system_alerts persistence) reste TODO.
-
 ### Action 2 — Découpage (persistence + workflow)
 
 | Patch | Description | Artifacts | Statut |
 |-------|-------------|-----------|--------|
-| 2.1 | DOC + SQL STAGING | `docs/db/spec_system_alerts.md`, `staging/sql/phase2/phase2_02_system_alerts.sql` | TODO |
+| 2.1 | DOC + SQL STAGING | `docs/db/spec_system_alerts.md`, `staging/sql/phase2/phase2_02_system_alerts.sql` | DONE (PROD) |
 | 2.2 | Job de sync (v_integrity_checks → system_alerts) | `staging/sql/phase2/phase2_03_system_alerts_sync.sql` | MERGED (PR #73) |
 | 2.3 | STAGING execution proof | — | DONE |
-| 2.4 | UI workflow ACK/RESOLVE | Flutter (IntegrityChecksScreen, repository) | TODO |
+| 2.4 | UI workflow ACK/RESOLVE | Flutter (IntegrityChecksScreen, repository) | DONE (PROD) |
 
 **Proof (STAGING)** :
 - system_alerts créée après sync (OPEN count = 1)
@@ -46,10 +44,23 @@
 
 **PR** : 2.2 merged via PR #73.
 
+**Evidence PROD (Action 2.4 — Feb 2026)** :
+- Table `public.system_alerts` + trigger `trg_system_alerts_set_actor`
+- Policies : `system_alerts_select_authenticated`, `system_alerts_update_admin_directeur`
+- Web déployé sur https://monaluxe.app (Firebase Hosting ml-pp-mvp-web)
+- Dette technique : `docs/POST_PROD/PHASE2_TECH_DEBT.md`
+
 ### PROD Validation Snapshot
 - CDR_ARRIVE_STALE: 5
 - No critical alerts
 - Backup validated
+
+### Action 7 — Evidence (DONE — RLS Hardening Feb 2026)
+- **Objectif** : Audit RLS + élimination des policies `{public}` (exposition ANON).
+- **STAGING** : DROP/migration policies `{public}` (log_actions, stocks_journaliers, citernes, puis 14 policies conditionnelles → `authenticated`). Vérif : count(public) = 0.
+- **PROD** : Correction fuites critiques (DROP `read stocks_journaliers`, DROP `read citernes`). Migration `{public}` → `{authenticated}` sur profils, cours_de_route, prises_de_hauteur, sorties_produit, stocks_journaliers. Vérif : count(public) = 0 ; curl ANON → `[]` sur tables sensibles.
+- **Docs** : `docs/POST_PROD/RUNBOOK_RLS_HARDENING.md`, `12_PHASE2_PROD_DEPLOY_LOG.md` (Entry 2), stratégie/plan mis à jour (standard "0 public policies").
+- **Rollback** : Recreate policy if needed (see runbook). No data mutation.
 
 ### Action 4 — Evidence (DONE DOC + IMPLEMENTATION)
 - Route: `/governance/integrity`
@@ -69,7 +80,7 @@
 
 ## Checkpoint actuel
 
-Phase 2 : Action 1 (v_integrity_checks) DONE ; Action 4 (Écran intégrité système) DONE (DOC + IMPLEMENTATION). Vue `public.v_integrity_checks` déployée. UI Integrity Checks exploitable en PROD. Backup PROD validé. Prochaine étape : Action 2 (system_alerts).
+Phase 2 : Action 1 (v_integrity_checks) DONE ; Action 2 (system_alerts + workflow ACK/RESOLVE) **DONE (PROD)** ; Action 4 (Écran intégrité système) DONE ; Action 7 (Audit RLS + hardening) DONE. Table `public.system_alerts` déployée avec trigger actor. UI Integrity Checks avec boutons ACK/RESOLVE en exploitation sur https://monaluxe.app. Dette technique documentée dans `docs/POST_PROD/PHASE2_TECH_DEBT.md`.
 
 ---
 

--- a/docs/POST_PROD/12_PHASE2_PROD_DEPLOY_LOG.md
+++ b/docs/POST_PROD/12_PHASE2_PROD_DEPLOY_LOG.md
@@ -43,3 +43,109 @@ DROP VIEW IF EXISTS public.v_integrity_checks;
 - Backup validated via pg_restore -l
 - No runtime impact detected
 - Change approved via PR merge before PROD execution
+
+---
+
+# Entry 2 — RLS Hardening (Remove public policies / Fix ANON exposure)
+
+## 1. Metadata
+- **Date (UTC)** : 2026-02-21 (timezone Africa/Kinshasa)
+- **Environment** : PROD
+- **Operator** : (compléter)
+- **Change ID** : Phase2-Action7-RLS-Hardening
+
+## 2. Change Description
+- **Trigger** : Audit RLS table-by-table revealed policies with `roles = {public}`; some were dangerous (`SELECT true`) → exposure via ANON REST (ANON key is embedded in Flutter Web front).
+- **Scope** : RLS policies only. No data mutation, no table/view/trigger schema change.
+- **Method** : STAGING-first (correct + validate), then PROD (audit + fix). One action at a time; curl ANON tests to prove exposure then closure.
+
+## 3. Pre-Deployment Checks
+- Backup PROD recommended before any RLS change (per runbook).
+- Identification of `{public}` policies via `pg_policies` (see Runbook).
+
+## 4. Actions Performed (PROD)
+1. **log_actions** : ANON test → `[]` (no leak).
+2. **stocks_journaliers** : ANON test → **data** (leak). Identified `read stocks_journaliers` {public} SELECT true → **DROP** policy → retest ANON → `[]`.
+3. **citernes** : ANON test → **data** (leak). Identified `read citernes` {public} SELECT true → **DROP** policy → retest ANON → `[]`.
+4. Global scan `pg_policies` : remaining `{public}` conditional policies migrated to `{authenticated}` on:
+   - profils (Insert/Read/Update own profile)
+   - stocks_journaliers_select
+   - cours_de_route_select, cours_de_route_insert
+   - prises_de_hauteur_select, prises_de_hauteur_insert
+   - sorties_produit_select, sp_read, sorties_produit_insert, sp_update_draft, sp_insert_draft, sp_delete
+5. Final check: `count(public policies) = 0`.
+
+## 5. Post-Deployment Validation (Proof)
+- Query: list policies by table; `SELECT count(*) FROM pg_policies WHERE roles @> ARRAY['public']::name[]` → **0**.
+- curl ANON (no real keys in doc):
+  - `stocks_journaliers` → `[]`
+  - `citernes` → `[]`
+
+## 6. Rollback Procedure
+If a legitimate use case requires a public policy (rare): recreate the policy with the same name and definition, then re-validate. Prefer `authenticated` + conditions over `public`. See `docs/POST_PROD/RUNBOOK_RLS_HARDENING.md`.
+
+## 7. Governance Notes
+- Zero data-destructive change.
+- Aligns STAGING and PROD (both 0 public policies).
+- Phase 2 Action 7 (Audit RLS) marked DONE; runbook and standard "0 public policies" added.
+
+---
+
+# Entry 3 — Governance ACK/RESOLVE Workflow (system_alerts + Web)
+
+## 1. Metadata
+- **Date (UTC)** : 2026-02 (post-Phase 2 Action 2.4)
+- **Environment** : PROD
+- **Operator** : (compléter)
+- **Change ID** : Phase2-Action2.4-Governance-ACK-RESOLVE
+
+## 2. Change Description
+
+### DB PROD — Migration appliquée
+
+**Table utilisée** : `public.system_alerts` (créée via phase2_02_system_alerts.sql puis déploiement PROD)
+
+**Colonnes concernées** :
+- `status` (OPEN / ACK / RESOLVED)
+- `acknowledged_at` (timestamptz)
+- `acknowledged_by` (uuid)
+- `resolved_at` (timestamptz)
+- `resolved_by` (uuid)
+
+**Policies RLS existantes** :
+- `system_alerts_select_authenticated` — SELECT pour utilisateurs authentifiés éligibles
+- `system_alerts_update_admin_directeur` — UPDATE restreint aux rôles admin et directeur
+
+⚠️ **Note** : La policy UPDATE actuelle compare `p.id = auth.uid()` (profil) et non `p.user_id = auth.uid()`. Dette technique documentée dans `docs/POST_PROD/PHASE2_TECH_DEBT.md`.
+
+**Trigger ajouté en PROD** :
+- Fonction : `system_alerts_set_actor()`
+- Trigger : `trg_system_alerts_set_actor`
+- **But** : Auto-remplissage de `acknowledged_at`, `acknowledged_by`, `resolved_at`, `resolved_by` lors des transitions de statut
+- ⚠️ **Limitation** : Le trigger ne s'active que si `status` change réellement (pas sur simple UPDATE sans changement de status)
+
+### Web Deploy
+
+**Build Flutter Web** :
+- Commande : `flutter build web --release --dart-define SUPABASE_URL=... --dart-define SUPABASE_ANON_KEY=...`
+- Secrets injectés exclusivement via `--dart-define`
+- Aucun fallback hardcodé
+
+**Déploiement Firebase Hosting** :
+- Commande : `firebase deploy`
+- Hosting cible : `ml-pp-mvp-web`
+- **URL PROD active** : https://monaluxe.app
+
+## 3. Pre-Deployment Checks
+- Backup PROD recommandé avant migration DB
+- Validation STAGING des scripts phase2_02 et phase2_03 (system_alerts + sync)
+- Validation UI Flutter sur environnement de test
+
+## 4. Post-Deployment Validation
+- Écran `/governance/integrity` accessible (admin, directeur, pca)
+- Boutons ACK / RESOLVE visibles pour admin et directeur uniquement
+- Cycle de vie OPEN → ACK → RESOLVED exploitable en exploitation réelle
+
+## 5. Governance Notes
+- Déploiement PROD validé
+- Dette technique identifiée et volontairement différée (voir PHASE2_TECH_DEBT.md)

--- a/docs/POST_PROD/INDEX.md
+++ b/docs/POST_PROD/INDEX.md
@@ -21,7 +21,10 @@
 - [09 — Phase 2 Stratégie](09_PHASE2_STRATEGIE.md)
 - [10 — Phase 2 Plan 10 Actions](10_PHASE2_PLAN_10_ACTIONS.md)
 - [11 — Phase 2 Tracker](11_PHASE2_TRACKER.md)
+- [12 — Phase 2 PROD Deploy Log](12_PHASE2_PROD_DEPLOY_LOG.md)
+- [Phase 2 Tech Debt](PHASE2_TECH_DEBT.md)
 - [Integrity Runbook](INTEGRITY_RUNBOOK.md)
+- [Runbook RLS Hardening](RUNBOOK_RLS_HARDENING.md)
 - [Spec Écran Intégrité](../app/spec_ecran_integrite_systeme.md)
 - [Spec system_alerts](../db/spec_system_alerts.md)
 

--- a/docs/POST_PROD/PHASE2_TECH_DEBT.md
+++ b/docs/POST_PROD/PHASE2_TECH_DEBT.md
@@ -1,0 +1,32 @@
+# Phase 2 — Dette technique documentée
+
+**Contexte** : Dette technique identifiée lors du déploiement Phase 2 — Action 2.4 (Governance ACK/RESOLVE workflow). Ces éléments sont connus et volontairement différés.
+
+---
+
+## 🧨 TECH-DEBT — Governance ACK/RESOLVE Workflow
+
+### Problèmes identifiés
+
+| # | Problème | Description |
+|---|----------|-------------|
+| 1 | `acknowledged_by` reste null dans certains cas | L'audit utilisateur n'est pas systématiquement renseigné |
+| 2 | UI ne désactive pas bouton ACK après mutation | L'état visuel du bouton peut rester "actif" après un ACK réussi |
+| 3 | Snackbar affiche succès même si mutation partielle | Feedback utilisateur potentiellement trompeur |
+| 4 | Policy UPDATE compare `p.id = auth.uid()` au lieu de `p.user_id = auth.uid()` | La policy RLS `system_alerts_update_admin_directeur` compare l'ID du profil (`profils.id`) avec `auth.uid()` au lieu de `profils.user_id` |
+| 5 | Provider Riverpod ne refetch pas après mutation | Rafraîchissement des données potentiellement incomplet |
+
+### Impact
+
+- **Non bloquant**
+- **Fonctionnel en exploitation**
+- Incohérence UI / audit partiel
+
+### Priorité
+
+**P3** (non critique)
+
+### Référence
+
+- Déploiement : Entry 3 — `docs/POST_PROD/12_PHASE2_PROD_DEPLOY_LOG.md`
+- Tracker : Action 2 — `docs/POST_PROD/11_PHASE2_TRACKER.md`

--- a/docs/POST_PROD/RUNBOOK_RLS_HARDENING.md
+++ b/docs/POST_PROD/RUNBOOK_RLS_HARDENING.md
@@ -1,0 +1,129 @@
+# Runbook — RLS Hardening (0 public policies)
+
+**Document** : Procédure et checklist pour l’audit et le durcissement RLS (Supabase Postgres).  
+**Version** : 1.0  
+**Date** : 2026-02-21  
+**Contexte** : ML_PP MVP en PROD — clé ANON exposée dans le front Flutter Web.
+
+---
+
+## Why this matters
+
+- **ANON key in front** : L’application Flutter Web embarque la clé **anon** Supabase. Toute requête REST (y compris sans JWT utilisateur) utilise cette clé.
+- **Policy `roles = {public}`** : Une policy RLS avec `TO public` (ou équivalent) s’applique à **tous** les rôles, y compris les connexions **non authentifiées** (header `Authorization: Bearer <ANON_KEY>` sans session).
+- **Risque** : Une policy du type `USING (true)` ou `WITH CHECK (true)` sur `public` → **exposition immédiate** des données de la table via l’API REST (liste, détail). Aucune authentification requise.
+- **Objectif** : **0 policy `{public}`** en PROD et STAGING. Toutes les policies ciblent `authenticated` (ou rôles explicites) avec une condition métier/technique.
+
+---
+
+## Protocole safe (une action à la fois)
+
+1. **Identifier** les policies concernées (requête `pg_policies`).
+2. **Tester** l’exposition : `curl` avec ANON key sur la table (sans JWT utilisateur).
+3. **Corriger** : DROP policy dangereuse ou migrer `public` → `authenticated` en conservant la condition.
+4. **Re-tester** : `curl` ANON doit retourner `[]` (ou 403) pour les tables sensibles.
+5. **Documenter** : déploiement log, runbook, CHANGELOG.
+
+**Environnement** : Toujours **STAGING d’abord** (correction + validation), puis **PROD** (audit + fix) après backup.
+
+---
+
+## Commandes / requêtes (preuves)
+
+### Test exposition ANON (sans clés réelles dans la doc)
+
+```bash
+# Remplacer <SUPABASE_URL> et <ANON_KEY> par les valeurs de l’env (jamais commiter les clés).
+curl -i -H "apikey: <ANON_KEY>" \
+     -H "Authorization: Bearer <ANON_KEY>" \
+     -H "Content-Type: application/json" \
+     "<SUPABASE_URL>/rest/v1/<TABLE>?select=id&limit=1"
+```
+
+- **HTTP 200 + body avec `data`** → fuite (policy `public` permissive).
+- **HTTP 200 + `[]`** ou **403** → pas d’exposition.
+
+### Lister les policies par table
+
+```sql
+SELECT schemaname, tablename, policyname, permissive, roles, cmd, qual
+FROM pg_policies
+WHERE schemaname = 'public'
+ORDER BY tablename, policyname;
+```
+
+### Compter les policies « public » restantes
+
+```sql
+SELECT count(*) AS public_policies_count
+FROM pg_policies
+WHERE schemaname = 'public'
+  AND roles @> ARRAY['public']::name[];
+```
+
+**Cible** : `0` après hardening.
+
+---
+
+## Checklist STAGING
+
+- [ ] Backup (ou confirmation pas de données critiques).
+- [ ] Exécuter requête `pg_policies` ; noter les policies `roles @> ARRAY['public']`.
+- [ ] Pour chaque table sensible : test curl ANON ; noter fuite ou `[]`.
+- [ ] DROP ou migrer les policies `{public}` (migration = recréer en `TO authenticated` avec la même condition).
+- [ ] Re-test curl ANON sur tables corrigées → `[]`.
+- [ ] Vérif finale : `count(public policies) = 0`.
+
+---
+
+## Checklist PROD
+
+- [ ] **Backup PROD** validé avant toute modification RLS.
+- [ ] Test ANON sur tables sensibles (ex. `log_actions`, `stocks_journaliers`, `citernes`, …).
+- [ ] Identifier policies en `{public}` (notamment `SELECT true`).
+- [ ] DROP policies dangereuses (ex. `read stocks_journaliers`, `read citernes` si `USING (true)` et `TO public`).
+- [ ] Migrer les autres `{public}` → `authenticated` (recréer policy avec `TO authenticated`, même `USING`/`WITH CHECK`).
+- [ ] Re-test curl ANON → `[]` sur les tables concernées.
+- [ ] Vérif finale : `SELECT count(*) FROM pg_policies WHERE schemaname = 'public' AND roles @> ARRAY['public']::name[]` → **0**.
+- [ ] Renseigner le déploiement log : `docs/POST_PROD/12_PHASE2_PROD_DEPLOY_LOG.md`.
+
+---
+
+## Rollback logique
+
+- **Aucune suppression de données** : les changements portent uniquement sur les policies RLS.
+- **Recreate policy** : si une policy a été supprimée par erreur, la recréer avec le même nom et la même expression, en ciblant `authenticated` (ou le rôle approprié). Exemple :
+
+```sql
+-- Exemple (adapter nom table, nom policy, condition)
+CREATE POLICY "read_citernes" ON public.citernes
+FOR SELECT TO authenticated
+USING (true);  -- ou une condition métier (ex. depot_id = app_current_depot_id())
+```
+
+- **En cas de régression** : réappliquer la policy migrée (authenticated) depuis la sauvegarde ou la doc ; re-tester l’app (login utilisateur) pour confirmer que les écrans fonctionnent.
+
+---
+
+## Risques résiduels / dette
+
+- **Drift** : Les futures migrations (nouveaux objets, nouvelles policies) peuvent réintroduire des policies `{public}`. **Revue obligatoire** de toute migration RLS.
+- **CI** : Aucun check automatique actuel. **Recommandation** : ajouter un script (SQL ou job CI) qui échoue si `count(public policies) > 0` en STAGING/PROD (ou sur export du schéma).
+- **Règle de revue** : Aucune policy `SELECT true` (ou équivalent permissif) pour le rôle `public`. Documenter cette règle dans la stratégie Phase 2 et dans le runbook des changements DB.
+
+---
+
+## Next actions
+
+1. **Check automatique** : Mettre en place un script (ex. SQL exécuté en CI ou avant déploiement) qui vérifie `count(public policies) = 0` et fait échouer le déploiement si non respecté.
+2. **Règle de revue** : Formaliser dans la revue de code / checklist DB : « Aucune policy RLS avec `TO public` et condition permissive (`true`) ».
+3. **Runbook DB changes** : Mettre à jour le runbook des changements DB (ou équivalent) pour inclure la vérification RLS (pas de policy publique) avant toute application en PROD.
+
+---
+
+## Références
+
+- **Stratégie Phase 2** : `docs/POST_PROD/09_PHASE2_STRATEGIE.md` (standard « 0 public policies »).
+- **Plan 10 actions** : `docs/POST_PROD/10_PHASE2_PLAN_10_ACTIONS.md` (Action 7).
+- **Déploiement PROD** : `docs/POST_PROD/12_PHASE2_PROD_DEPLOY_LOG.md` (Entry 2 — RLS Hardening).
+- **Tracker** : `docs/POST_PROD/11_PHASE2_TRACKER.md` (Action 7 DONE).


### PR DESCRIPTION
## 🔐 RLS Hardening — STAGING + PROD

### Context

During a post-production security audit, we discovered that several RLS policies were still assigned to `{public}`, including unconditional `SELECT true` policies.

Because the ANON key is embedded in the Flutter Web frontend, this created a potential data exposure vector via REST API.

### Actions Taken

#### STAGING
- Audited all tables via ANON curl tests
- Removed unsafe `{public}` policies
- Migrated conditional policies from `{public}` → `{authenticated}`
- Verified: public policies count = 0

#### PROD
- Confirmed ANON exposure on:
  - `stocks_journaliers`
  - `citernes`
- Removed `read stocks_journaliers` and `read citernes` public policies
- Migrated remaining `{public}` conditional policies to `{authenticated}`
- Verified via curl:
  - ANON REST returns `[]`
- Verified via SQL:
  - `count(public policies) = 0`

### Security Impact

- ANON key can no longer read business data
- All access now requires authenticated JWT
- RLS posture aligned with zero-public-policy standard

### Documentation Added

- Updated CHANGELOG
- Updated PROD_DEPLOY_LOG
- Updated Phase 2 tracker
- Updated overview + strategy docs
- Added `RUNBOOK_RLS_HARDENING.md`
- Added `PHASE2_TECH_DEBT.md`

### Next Steps

- Add CI check to prevent reintroduction of `{public}` policies
- Add automated RLS audit script
- Enforce review rule: no `SELECT true` policies allowed