### PR TITLE
Docs: Update industrial maturity status (post RLS hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 
 ## [Unreleased]
 
+### Documentation
+- **Docs** : Reclassification industrial status after RLS hardening (PR #75, 7297c7c)
+- **Docs** : Industrial maturity table + history in README (Phase Initiale → Transition → Opérationnel)
+
+---
+
 ### ✨ Phase 2 — Governance ACK/RESOLVE Workflow (Feb 2026)
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -3,26 +3,53 @@
 **Objectif** : Application de gestion logistique pétrolière pour Monaluxe  
 **Stack technique** : Flutter + Supabase + Riverpod + GoRouter + Clean Architecture
 
-> ⚠️ **SPRINT EN COURS (31/12/2025) :** Finalisation production industrielle  
-> 📋 [Sprint Prod-Ready 10-15 jours](docs/SPRINT_PROD_READY_2025-12-31.md) | [Suivi](docs/SUIVI_SPRINT_PROD_READY.md)
+---
 
-**Objectif Sprint :** ML_PP MVP déployable en production industrielle auditée
+## 📊 Statut Global — Industrial Maturity (Feb 2026)
 
-**Avancement :** 0/11 tickets (0%)
-- 🔴 AXE A (DB-STRICT) : 0/3
-- 🔴 AXE B (Tests DB) : 0/2
-- 🔴 AXE C (Sécurité) : 0/2
-- 🟡 AXE D (Stabilisation) : 0/4
+- GO PROD official (tag `go-prod-2026-01`)
+- E2E business flow validated: CDR → Réception → Stock → Sortie
+- Canonical stock source: `v_stock_actuel`
+- Front live: https://monaluxe.app
+- CI green (PR + Nightly)
+- RLS hardening complete: 0 `{public}` policies
 
-**Verdict actuel :**
-- 🟢 **Fonctionnel : GO** (production interne contrôlée)
-- 🔴 **Industriel : NO-GO** (chantiers P0 requis : 7-10j)
+## 🏗️ Maturité Industrielle — Évaluation Structurée
 
-**Décision :**
-- ✅ GO production interne contrôlée
-- ❌ NO-GO production industrielle auditée (points 1-6 requis)
+| Domaine | Statut | Niveau |
+|---------|--------|--------|
+| Flux métier DB | Validé & Trigger-unified | 🟢 Stable |
+| Sécurité RLS | 0 policy `{public}` | 🟢 Hardened |
+| Exposition ANON REST | Neutralisée | 🟢 Secure |
+| Gouvernance Git | PR obligatoire + CI verte | 🟢 Industriel |
+| Documentation | Traçable & versionnée | 🟢 Mature |
+| Infra Front | Firebase + SSL + DNS propre | 🟢 Stable |
+| Tests Flutter | Majoritairement isolés | 🟡 Avancé |
+| Tests DB triggers | Partiellement automatisés | 🟡 En consolidation |
+| Guardrails CI sécurité | Non encore implémentés | 🟡 À implémenter |
+| Monitoring métier | Phase 2 en cours | 🟡 En progression |
 
-📋 **[Voir le rapport complet →](docs/RAPPORT_SYNTHESE_PRODUCTION_2025-12-31.md)**
+## 🎯 Conclusion Officielle
+
+- 🟢 **Industriel opérationnel**
+- 🟡 Industrialisation avancée en cours (Automation & Monitoring)
+- Aucune dette critique connue à date de ce checkpoint.
+
+## 📈 Historique de Maturité Industrielle
+
+### 🔴 Phase Initiale — "Industriel : NO-GO" (Jan 2026)
+
+Verdict conservative, orienté audit. Les axes A–D (DB-STRICT, Tests DB, Sécurité, Stabilisation) restaient ouverts. Risque identifié : policies `{public}` + exposition potentielle ANON REST.
+
+📋 Rapport d'époque : [docs/90_ARCHIVE/RAPPORT_SYNTHESE_PRODUCTION_2025-12-31.md](docs/90_ARCHIVE/RAPPORT_SYNTHESE_PRODUCTION_2025-12-31.md)
+
+### 🟡 Phase Transition — RLS Hardening (21 Feb 2026)
+
+Audit STAGING + PROD ; migration `{public}` → `{authenticated}` ; curl ANON retourne vide sur tables sensibles. Documenté et mergé (PR #75, commit 7297c7c).
+
+### 🟢 Phase Actuelle — Industriel Opérationnel (Late Feb 2026)
+
+État actuel : RLS durci, front en exploitation. Restant : guardrails CI sécurité, automatisation tests DB triggers, monitoring métier Phase 2.
 
 ---
 

--- a/docs/POST_PROD/00_OVERVIEW.md
+++ b/docs/POST_PROD/00_OVERVIEW.md
@@ -39,3 +39,5 @@ Faire évoluer ML_PP vers une plateforme ERP pétrolière modulaire :
 - **Constat** : Audit RLS a révélé des policies `roles = {public}` (dont `SELECT true`) → exposition possible via ANON REST (clé ANON embarquée dans le front Flutter Web).
 - **Résultat** : STAGING et PROD durcis — **0 policy `{public}`** restante. Fuites critiques corrigées (ex. `stocks_journaliers`, `citernes`). Toute policy cible désormais `authenticated` (ou rôles explicites) avec conditions.
 - **Docs** : `docs/POST_PROD/RUNBOOK_RLS_HARDENING.md`, `12_PHASE2_PROD_DEPLOY_LOG.md` (Entry 2). Standard post-prod : **aucune policy publique** ; revue obligatoire pour toute nouvelle policy.
+
+**Statut README** : Mis à jour (fév 2026) — passage de "Industriel NO-GO" à "Industriel opérationnel" suite au RLS hardening. Voir `README.md` sections « Statut Global », « Maturité Industrielle », « Historique ». Références : [RUNBOOK_RLS_HARDENING.md](RUNBOOK_RLS_HARDENING.md), [PHASE2_TECH_DEBT.md](PHASE2_TECH_DEBT.md).

--- a/docs/POST_PROD/11_PHASE2_TRACKER.md
+++ b/docs/POST_PROD/11_PHASE2_TRACKER.md
@@ -84,6 +84,12 @@ Phase 2 : Action 1 (v_integrity_checks) DONE ; Action 2 (system_alerts + workflo
 
 ---
 
+## Note — Statut README (Feb 2026)
+
+Le README racine a été mis à jour : reclassification "Industriel NO-GO" → "Industriel opérationnel" suite au RLS hardening (0 policy `{public}`). Références : [RUNBOOK_RLS_HARDENING.md](RUNBOOK_RLS_HARDENING.md), [PHASE2_TECH_DEBT.md](PHASE2_TECH_DEBT.md).
+
+---
+
 ## Règles d'update
 
 À chaque PR ou commit lié à la Phase 2 :


### PR DESCRIPTION
## Summary
This PR updates project documentation to reflect the current industrial maturity level after RLS hardening.

## What changed
- README: reclassifies “Industriel: NO-GO” to **“Industriel opérationnel / industrialisation avancée en cours”**
- README: adds an **industrial maturity table** and an **historical timeline** (NO-GO → transition → current state)
- POST_PROD: aligns overview + Phase 2 tracker with the updated status
- CHANGELOG: documents the documentation update

## Rationale
RLS hardening has been completed (0 `{public}` policies) and ANON REST no longer returns business data, so the historical “NO-GO industriel” status is no longer accurate. This PR keeps the history while reflecting the current reality and remaining automation/monitoring work.

## Scope
Docs-only. No Dart/Flutter, SQL, CI, or runtime changes.

## Files changed
- `README.md`
- `CHANGELOG.md`
- `docs/POST_PROD/00_OVERVIEW.md`
- `docs/POST_PROD/11_PHASE2_TRACKER.md`

## Validation
- [ ] Documentation reads consistently (no contradictions across README / POST_PROD)
- [ ] CI green