### PR TITLE
docs: ASTM 53B migration — Pre-backup documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 ### Documentation
 - **Docs** : Reclassification industrial status after RLS hardening (PR #75, 7297c7c)
 - **Docs** : Industrial maturity table + history in README (Phase Initiale → Transition → Opérationnel)
+- **Docs** : Runbook et entrée tracker pour migration volumétrique PROD ASTM 53B (pre-backup)
 
 ---
 

--- a/docs/POST_PROD/00_OVERVIEW.md
+++ b/docs/POST_PROD/00_OVERVIEW.md
@@ -41,3 +41,23 @@ Faire évoluer ML_PP vers une plateforme ERP pétrolière modulaire :
 - **Docs** : `docs/POST_PROD/RUNBOOK_RLS_HARDENING.md`, `12_PHASE2_PROD_DEPLOY_LOG.md` (Entry 2). Standard post-prod : **aucune policy publique** ; revue obligatoire pour toute nouvelle policy.
 
 **Statut README** : Mis à jour (fév 2026) — passage de "Industriel NO-GO" à "Industriel opérationnel" suite au RLS hardening. Voir `README.md` sections « Statut Global », « Maturité Industrielle », « Historique ». Références : [RUNBOOK_RLS_HARDENING.md](RUNBOOK_RLS_HARDENING.md), [PHASE2_TECH_DEBT.md](PHASE2_TECH_DEBT.md).
+
+---
+
+## PROD Operation — Volumetric Migration to ASTM 53B (Gasoil)
+
+**Constat** : Écart volumétrique confirmé entre ML_PP et l'app terrain ASTM : ~50–70 L par opération sur GASOIL. L'app terrain (ASTM 53B) fournit densité observée + température → densité@15 + VCF.
+
+**Risque** : Cumul financier, prévention litiges facturation. Aucune facture fournisseur émise à ce jour ; aucun paiement engagé.
+
+**Statut opérationnel** : **SORTIES FREEZE** en exploitation contrôlée jusqu'à completion de la migration. Deux sorties prévues aujourd'hui dépendent du stock actuel → opérations gelées.
+
+**Périmètre** : GASOIL uniquement ; 8 réceptions depuis début du mois ; 2 citernes ; chronologie validée, aucune édition post-validation.
+
+**Stratégie choisie** : Industriel strict — ML_PP devient la source officielle du calcul volumétrique (moteur ASTM en Dart, résultats stockés en DB avec garde-fous).
+
+**Plan général** : Backup → Validation moteur → Simulation (8 réceptions) → Migration DB → Rebuild stock → Reprise opérations.
+
+**STOP gate** : Aucune modification DB avant backup complet et rapport de simulation validé.
+
+**Runbook** : [RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md](RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md)

--- a/docs/POST_PROD/11_PHASE2_TRACKER.md
+++ b/docs/POST_PROD/11_PHASE2_TRACKER.md
@@ -55,6 +55,30 @@
 - No critical alerts
 - Backup validated
 
+---
+
+## PROD Operation — ASTM 53B Volumetric Migration
+
+**Statut** : IN PROGRESS — PRE-BACKUP DOC
+
+**Runbook** : [RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md](RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md)
+
+**Checklist** :
+- [ ] Doc package créé (ce PR)
+- [ ] Backup PROD effectué
+- [ ] Golden dataset capturé (20–30 cas) + suite de tests verte
+- [ ] Rapport de simulation approuvé (8 réceptions)
+- [ ] Migration exécutée + rebuild stock fait
+- [ ] Sorties dégelées
+- [ ] Vérification post-migration (spot checks vs app ASTM)
+
+**Risk / Notes** :
+- Ne pas valider de sorties pendant l'opération.
+- Aucune mise à jour silencieuse ; logger l'événement global.
+- Sémantique : `densite_a_15` est un misnomer actuel (stocke la densité observée, pas la densité@15).
+
+---
+
 ### Action 7 — Evidence (DONE — RLS Hardening Feb 2026)
 - **Objectif** : Audit RLS + élimination des policies `{public}` (exposition ANON).
 - **STAGING** : DROP/migration policies `{public}` (log_actions, stocks_journaliers, citernes, puis 14 policies conditionnelles → `authenticated`). Vérif : count(public) = 0.

--- a/docs/POST_PROD/PHASE2_TECH_DEBT.md
+++ b/docs/POST_PROD/PHASE2_TECH_DEBT.md
@@ -30,3 +30,22 @@
 
 - Déploiement : Entry 3 — `docs/POST_PROD/12_PHASE2_PROD_DEPLOY_LOG.md`
 - Tracker : Action 2 — `docs/POST_PROD/11_PHASE2_TRACKER.md`
+
+---
+
+## 🧨 TECH-DEBT — Volumetric Standardization
+
+### Problème identifié
+
+- **Misnomer** : `densite_a_15` stocke actuellement la densité **observée** (ambiant), pas la densité@15.
+- **Manque** : Pas de champs explicites pour `observed_density`, `computed_density_at_15`, `VCF` ; pas de support Volume@20.
+
+### Évolution prévue
+
+- Renommer / clarifier `densite_a_15` (densité observée vs densité@15).
+- Introduire explicitement : `observed_density`, `computed_density_at_15`, `VCF`.
+- Ajouter support Volume@20 si besoin métier.
+
+### Contexte
+
+- Migration ASTM 53B en cours : [RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md](RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md)

--- a/docs/POST_PROD/RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md
+++ b/docs/POST_PROD/RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md
@@ -1,0 +1,107 @@
+# Runbook — Volumetrics ASTM 53B Migration (PROD)
+
+**Document** : Procédure et checklist pour la migration volumétrique PROD vers ASTM 53B (Gasoil).  
+**Version** : 1.0  
+**Contexte** : ML_PP MVP en PROD — écart volumétrique confirmé (~50–70 L) vs app terrain ASTM ; gel des sorties jusqu'à completion.
+
+---
+
+## Purpose & Scope
+
+- **Objectif** : Aligner le calcul volumétrique ML_PP sur la référence ASTM 53B, faire de ML_PP la source officielle pour les volumes@15.
+- **Périmètre** : GASOIL uniquement ; 8 réceptions PROD ; 2 citernes.
+- **Approche** : Moteur ASTM en Dart (fonctions pures) ; résultats stockés en DB ; contraintes/logs en garde-fou. Pas d'implémentation dans ce doc — définition uniquement.
+
+---
+
+## Definitions
+
+| Terme | Définition |
+|-------|------------|
+| **Observed density** | Densité mesurée à la température ambiante (terrain). Actuellement stockée dans `densite_a_15` (misnomer). |
+| **Density@15** | Densité corrigée à 15°C, calculée à partir de la densité observée + température. |
+| **VCF** | Volume Correction Factor — facteur de correction du volume pour ramener à 15°C (ou 20°C selon convention). L'app ASTM l'affiche. |
+| **Volume@15** | Volume corrigé à 15°C (volume_ambiant × VCF). |
+| **Volume@20** | Volume corrigé à 20°C. Non implémenté pour l'instant ; support futur possible. |
+| **ASTM 53B** | Table/code ASTM pour produits pétroliers (Gasoil) — conversion densité/température/volume. L'app terrain utilise cette référence. |
+
+---
+
+## Preconditions
+
+1. **Freeze sorties** : Aucune sortie validée pendant l'opération.
+2. **Confirmer absence factures/paiements** : Aucune facture fournisseur émise ; aucun paiement engagé.
+3. **Tolérances** : ±0,1 % (volume et montant) pour détection d'anomalies.
+
+---
+
+## Phases (Step-by-Step)
+
+### Phase 1 — Backup (required)
+
+- Créer un backup complet PROD avant toute modification.
+- Valider le backup (`pg_restore -l` ou équivalent).
+- **STOP gate** : Pas de changement DB tant que le backup n'est pas validé.
+
+### Phase 2 — Data Export (required)
+
+- Exporter les 8 réceptions concernées (id, citerne_id, produit_id, volume_ambiant, temperature_ambiante_c, densite_a_15, volume_corrige_15c, etc.).
+- Sauvegarder l'export pour référence et rollback.
+
+### Phase 3 — Build ASTM Engine (Dart) + Golden Tests (required)
+
+- Implémenter le moteur ASTM 53B en Dart (fonctions pures).
+- Créer un jeu de tests golden (20–30 cas) validés contre l'app ASTM ou des tableaux de référence.
+- **Cible** : Suite de tests verte avant simulation.
+
+### Phase 4 — Simulation Report (required)
+
+- Appliquer le moteur sur les 8 réceptions (mode simulation, sans écriture DB).
+- Générer un rapport : volumes avant/après, écarts, VCF calculés.
+- **STOP gate** : Rapport approuvé avant toute migration.
+- Tolérance : VCF et Volume@15 dans ±0,1 % vs app ASTM.
+
+### Phase 5 — Migration Execution (DB updates)
+
+- Mise à jour conceptuelle : modifier les 8 lignes `receptions` avec les nouveaux volumes calculés (volume_corrige_15c, et éventuellement densite_a_15 corrigée selon décision sémantique).
+- Aucune implémentation SQL dans ce runbook — à définir dans une spec d'implémentation.
+- **Logging** : Enregistrer un événement global `VOLUMETRICS_METHOD_MIGRATION_ASTM53B_V1` dans `log_actions` (nom défini ; non implémenté ici).
+
+### Phase 6 — Stock Rebuild (conceptual)
+
+- Recalculer les stocks par citerne à partir des réceptions migrées et des sorties existantes.
+- Mécanisme à définir (trigger, script, ou recalcul via `stocks_journaliers` / `v_stock_actuel` selon l'architecture).
+
+### Phase 7 — Verification Checklist
+
+- VCF calculé vs app ASTM : dans tolérance.
+- Volume@15 vs app ASTM : dans tolérance.
+- Stock par citerne : réconciliation OK.
+- Sorties : dégel autorisé.
+
+### Phase 8 — Rollback Plan
+
+- En cas d'anomalie : restore depuis le backup.
+- Re-freeze des opérations (sorties) jusqu'à nouvelle décision.
+
+---
+
+## Acceptance Criteria
+
+- VCF matches field app within ±0,1 %.
+- Volume@15 matches within ±0,1 %.
+- Stock per citerne reconciles.
+- Sorties can resume safely.
+
+---
+
+## Logging Requirement
+
+- Enregistrer un événement global : `VOLUMETRICS_METHOD_MIGRATION_ASTM53B_V1` (nom défini ; implémentation à prévoir en `log_actions`).
+
+---
+
+## Post-Migration Notes
+
+- **Futur** : Étendre à ASTM 54B si autres produits apparaissent.
+- **Finance** : Le module Finance dépend de la stabilisation de ce socle volumétrique.


### PR DESCRIPTION
Documentation industrielle mise à jour avant déclenchement du backup PROD :

- UPDATE CHANGELOG
- UPDATE POST_PROD overview
- UPDATE Phase 2 Tracker
- UPDATE Tech Debt
- ADD runbook volumétrique ASTM 53B

Étape obligatoire avant exécution du backup PROD.