### PR TITLE
docs(post-prod): document PROD backup pre-migration ASTM 53B (2026-02-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 
 ## [Unreleased]
 
+### Added
+- Backup PROD pré-migration ASTM 53B : `backups/prod_pre_astm53b_20260221_2253_data.dump`
+
 ### Documentation
 - **Docs** : Reclassification industrial status after RLS hardening (PR #75, 7297c7c)
 - **Docs** : Industrial maturity table + history in README (Phase Initiale → Transition → Opérationnel)

--- a/docs/POST_PROD/00_OVERVIEW.md
+++ b/docs/POST_PROD/00_OVERVIEW.md
@@ -61,3 +61,5 @@ Faire évoluer ML_PP vers une plateforme ERP pétrolière modulaire :
 **STOP gate** : Aucune modification DB avant backup complet et rapport de simulation validé.
 
 **Runbook** : [RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md](RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md)
+
+**Backup PROD 2026-02-21** : `backups/prod_pre_astm53b_20260221_2253_data.dump` — Snapshot de référence avant migration du calcul volume@15°C vers ASTM 53B (réceptions GASOIL).

--- a/docs/POST_PROD/11_PHASE2_TRACKER.md
+++ b/docs/POST_PROD/11_PHASE2_TRACKER.md
@@ -65,7 +65,7 @@
 
 **Checklist** :
 - [ ] Doc package créé (ce PR)
-- [ ] Backup PROD effectué
+- [x] Backup PROD effectué : `backups/prod_pre_astm53b_20260221_2253_data.dump` (pré-requis avant BLOC 2 — moteur ASTM 53B)
 - [ ] Golden dataset capturé (20–30 cas) + suite de tests verte
 - [ ] Rapport de simulation approuvé (8 réceptions)
 - [ ] Migration exécutée + rebuild stock fait


### PR DESCRIPTION
Documentation du backup PROD réalisé avant la migration volumétrique ASTM 53B.
- Ajout dans CHANGELOG.md
- Mise à jour du 00_OVERVIEW.md (section opérations critiques)
- Mise à jour du PHASE2_TRACKER (pré-requis BLOC 2)

Backup : backups/prod_pre_astm53b_20260221_2253_data.dump