### PR TITLE
docs(volumetrics): document ASTM 53B engine skeleton (Phase 2 — BLOC 2 Étape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 
 ### Added
 - Backup PROD pré-migration ASTM 53B : `backups/prod_pre_astm53b_20260221_2253_data.dump`
+- Moteur volumétrique ASTM 53B (squelette) ajouté dans `lib/core/volumetrics/astm53b_engine.dart` avec tests dédiés (`test/core/volumetrics/astm53b_engine_test.dart`), prêt pour l'implémentation des formules et des golden tests.
 
 ### Documentation
 - **Docs** : Reclassification industrial status after RLS hardening (PR #75, 7297c7c)

--- a/docs/POST_PROD/00_OVERVIEW.md
+++ b/docs/POST_PROD/00_OVERVIEW.md
@@ -63,3 +63,5 @@ Faire évoluer ML_PP vers une plateforme ERP pétrolière modulaire :
 **Runbook** : [RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md](RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md)
 
 **Backup PROD 2026-02-21** : `backups/prod_pre_astm53b_20260221_2253_data.dump` — Snapshot de référence avant migration du calcul volume@15°C vers ASTM 53B (réceptions GASOIL).
+
+- **Moteur volumétrique ASTM 53B (Étape A)** : ajout d'un module core dédié (`lib/core/volumetrics/astm53b_engine.dart`) avec API stable (densité observée + température + volume observé → densité@15, VCF, volume@15) et tests unitaires taggés `astm53b`. À ce stade, le moteur lève encore un `UnimplementedError` : aucune formule ASTM n'est utilisée en PROD tant que les golden cases et les tolérances n'ont pas été validés.

--- a/docs/POST_PROD/11_PHASE2_TRACKER.md
+++ b/docs/POST_PROD/11_PHASE2_TRACKER.md
@@ -66,6 +66,7 @@
 **Checklist** :
 - [ ] Doc package créé (ce PR)
 - [x] Backup PROD effectué : `backups/prod_pre_astm53b_20260221_2253_data.dump` (pré-requis avant BLOC 2 — moteur ASTM 53B)
+- [x] BLOC 2 / Étape A — Squelette moteur ASTM 53B : `lib/core/volumetrics/astm53b_engine.dart` + `test/core/volumetrics/astm53b_engine_test.dart` (tests taggés `astm53b`). Moteur non implémenté (UnimplementedError) ; aucune incidence PROD.
 - [ ] Golden dataset capturé (20–30 cas) + suite de tests verte
 - [ ] Rapport de simulation approuvé (8 réceptions)
 - [ ] Migration exécutée + rebuild stock fait

--- a/docs/POST_PROD/RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md
+++ b/docs/POST_PROD/RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md
@@ -54,6 +54,12 @@
 - Créer un jeu de tests golden (20–30 cas) validés contre l'app ASTM ou des tableaux de référence.
 - **Cible** : Suite de tests verte avant simulation.
 
+#### BLOC 2 — Moteur ASTM 53B
+
+1. [x] **Étape A** — Créer le squelette du moteur volumétrique ASTM 53B en Dart pur (`lib/core/volumetrics/astm53b_engine.dart`) + tests unitaires taggés `astm53b` (`test/core/volumetrics/astm53b_engine_test.dart`), avec `DefaultAstm53bCalculator` qui lève `UnimplementedError`.
+2. [ ] **Étape B** — Définir les golden cases (réceptions PROD + app terrain) et les tolérances numériques.
+3. [ ] **Étape C** — Implémenter les formules ASTM 53B / API MPMS 11.1 et brancher le moteur dans le flux Réception.
+
 ### Phase 4 — Simulation Report (required)
 
 - Appliquer le moteur sur les 8 réceptions (mode simulation, sans écriture DB).


### PR DESCRIPTION
PR Description
Cette PR documente l’intégralité de l’Étape A du BLOC 2 (migration volumétrique ASTM 53B — moteur Flutter) :
1. Documentation ajoutée
CHANGELOG.md → ajout de l’entrée [Unreleased] pour la création du squelette du moteur ASTM 53B.
docs/POST_PROD/00_OVERVIEW.md → mise à jour de la section Volumetrics Migration avec référence au moteur Flutter.
docs/POST_PROD/11_PHASE2_TRACKER.md → cases cochées + progression mise à jour pour le BLOC 2 Étape A.
docs/POST_PROD/RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md → ajout du sous-chapitre « Étape A — Création du squelette moteur (Flutter) ».
2. Contexte
Ce travail prépare la migration complète vers ASTM D1250 Table 53B :
moteur volumétrique côté Flutter créé dans lib/core/volumetrics/
tests associés créés dans test/core/volumetrics/
aucune intégration à l’UI ou aux modules métiers pour le moment
3. Objectif de la PR
Assurer une traçabilité documentaire totale avant de passer à l’Étape B : dataset + interpolation + VCF réel.
Aucun impact runtime. Aucun changement de DB. Sécuritaire pour PROD.