### PR TITLE
feat(volumetrics): add ASTM 53B golden dataset skeleton + documentation (Phase 2 — BLOC 2 Étape B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 
 ### Added
 - Backup PROD pré-migration ASTM 53B : `backups/prod_pre_astm53b_20260221_2253_data.dump`
+- Dataset ASTM 53B (BLOC 2 — Étape B) : structure des golden cases (`astm53b_golden_cases.dart`) + test golden skeleton.
 
 ### Documentation
 - **Docs** : Reclassification industrial status after RLS hardening (PR #75, 7297c7c)

--- a/docs/POST_PROD/00_OVERVIEW.md
+++ b/docs/POST_PROD/00_OVERVIEW.md
@@ -62,4 +62,8 @@ Faire évoluer ML_PP vers une plateforme ERP pétrolière modulaire :
 
 **Runbook** : [RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md](RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md)
 
+- **Étape B — Dataset golden ASTM 53B (créé)**  
+  Structure des cas de référence (`kAstm53bGoldenCases`) + test golden squelette.  
+  Aucun impact en production ; prépare la calibration moteur.
+
 **Backup PROD 2026-02-21** : `backups/prod_pre_astm53b_20260221_2253_data.dump` — Snapshot de référence avant migration du calcul volume@15°C vers ASTM 53B (réceptions GASOIL).

--- a/docs/POST_PROD/11_PHASE2_TRACKER.md
+++ b/docs/POST_PROD/11_PHASE2_TRACKER.md
@@ -72,6 +72,19 @@
 - [ ] Sorties dégelées
 - [ ] Vérification post-migration (spot checks vs app ASTM)
 
+**BLOC 2 — Progression ASTM 53B** :
+
+| Étape | Description | Statut |
+|-------|--------------|--------|
+| A | Squelette moteur ASTM 53B (astm53b_engine.dart) | [x] Fait |
+| B | Dataset golden ASTM 53B (structure + tests) | [x] Fait |
+| C | Calibration moteur + formule ASTM 53B | [ ] À faire |
+
+**Notes Étape B** :
+- Fichier : `lib/core/volumetrics/astm53b_golden_cases.dart`
+- Test : `test/core/volumetrics/astm53b_golden_test.dart`
+- Valeurs encore placeholders ; calibration prévue Étape C.
+
 **Risk / Notes** :
 - Ne pas valider de sorties pendant l'opération.
 - Aucune mise à jour silencieuse ; logger l'événement global.

--- a/docs/POST_PROD/RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md
+++ b/docs/POST_PROD/RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md
@@ -86,6 +86,26 @@
 
 ---
 
+## BLOC 2 — Progression
+
+### Étape A — Squelette moteur ASTM 53B
+- Objectif : poser les types et le contrat (Astm53bInput, Astm53bResult, Astm53bCalculator).
+- Fichier : `lib/core/volumetrics/astm53b_engine.dart`
+- Statut : **terminé**.
+
+### Étape B — Dataset golden ASTM 53B
+- Objectif : créer la structure des cas de référence pour valider le moteur ASTM 53B.
+- Fichiers introduits :
+  - `lib/core/volumetrics/astm53b_golden_cases.dart`
+  - `test/core/volumetrics/astm53b_golden_test.dart`
+- Statut : **terminé**.
+- Remarque : Les valeurs golden sont temporaires ; calibration prévue Étape C.
+
+### Étape C — Calibration moteur
+- À faire : implémentation formule ASTM 53B + calibration sur cas terrain.
+
+---
+
 ## Acceptance Criteria
 
 - VCF matches field app within ±0,1 %.

--- a/lib/core/volumetrics/astm53b_golden_cases.dart
+++ b/lib/core/volumetrics/astm53b_golden_cases.dart
@@ -1,0 +1,67 @@
+// lib/core/volumetrics/astm53b_golden_cases.dart
+
+import 'package:ml_pp_mvp/core/volumetrics/astm53b_engine.dart';
+
+/// Représente un cas "golden" pour valider le moteur ASTM 53B.
+///
+/// L'objectif de ces cas :
+/// - reproduire exactement les résultats de l'application terrain ASTM
+/// - garantir que ML_PP génère les mêmes densités@15, VCF et volumes@15
+/// - servir de base à des tests de non-régression.
+///
+/// Remarque :
+/// - Les valeurs peuvent être issues de réceptions PROD existantes.
+/// - Dans un premier temps, ce fichier peut contenir des placeholders.
+/// - Les valeurs seront raffinées au fur et à mesure de la calibration.
+class Astm53bGoldenCase {
+  /// Identifiant technique du cas (peut faire référence à une réception PROD).
+  final String id;
+
+  /// Entrée observée (densité, température, volume observé).
+  final Astm53bInput input;
+
+  /// Densité à 15 °C attendue (issue de l'app terrain), en kg/m³.
+  final double expectedDensity15KgPerM3;
+
+  /// VCF attendu (Volume Correction Factor).
+  final double expectedVcf;
+
+  /// Volume corrigé à 15 °C attendu, en litres.
+  final double expectedVolume15Liters;
+
+  /// Commentaire optionnel (ex: "Réception SEP 14/02/2026 - camion 1").
+  final String? comment;
+
+  const Astm53bGoldenCase({
+    required this.id,
+    required this.input,
+    required this.expectedDensity15KgPerM3,
+    required this.expectedVcf,
+    required this.expectedVolume15Liters,
+    this.comment,
+  });
+}
+
+/// Liste des cas golden actuellement définis pour ASTM 53B.
+///
+/// IMPORTANT :
+/// - Au début, cette liste peut être partiellement ou totalement vide.
+/// - Les valeurs "expected" doivent être remplies uniquement lorsque
+///   les résultats terrain sont confirmés.
+/// - Ce fichier est versionné comme une référence métier.
+const List<Astm53bGoldenCase> kAstm53bGoldenCases = <Astm53bGoldenCase>[
+  // Exemple de placeholder à adapter avec de vraies valeurs terrain :
+  //
+  // Astm53bGoldenCase(
+  //   id: 'reception_sep_20260214_camion1',
+  //   input: Astm53bInput(
+  //     densityObservedKgPerM3: 0.843 * 1000,
+  //     temperatureObservedC: 22.4,
+  //     volumeObservedLiters: 39291,
+  //   ),
+  //   expectedDensity15KgPerM3: 845.0, // TODO: valeur réelle
+  //   expectedVcf: 0.995,              // TODO: valeur réelle
+  //   expectedVolume15Liters: 39102.0, // TODO: valeur réelle
+  //   comment: 'Placeholder, à calibrer avec app ASTM terrain.',
+  // ),
+];

--- a/test/core/volumetrics/astm53b_golden_test.dart
+++ b/test/core/volumetrics/astm53b_golden_test.dart
@@ -1,0 +1,35 @@
+// test/core/volumetrics/astm53b_golden_test.dart
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ml_pp_mvp/core/volumetrics/astm53b_engine.dart';
+import 'package:ml_pp_mvp/core/volumetrics/astm53b_golden_cases.dart';
+
+@Tags(['astm53b', 'golden'])
+void main() {
+  group('Astm53bGoldenCases', () {
+    test('la liste des cas golden est définie (peut être vide au début)', () {
+      // On ne force pas à avoir déjà des cas, mais on vérifie au moins
+      // que la constante est bien accessible.
+      expect(kAstm53bGoldenCases, isNotNull);
+    });
+  });
+
+  group('DefaultAstm53bCalculator golden cases', () {
+    test(
+      'ne s\'exécute pas tant que le moteur ASTM 53B n\'est pas implémenté',
+      () {
+        const calculator = DefaultAstm53bCalculator();
+
+        for (final goldenCase in kAstm53bGoldenCases) {
+          expect(
+            () => calculator.compute(goldenCase.input),
+            throwsA(isA<UnimplementedError>()),
+          );
+        }
+      },
+      skip: kAstm53bGoldenCases.isEmpty
+          ? 'Pas encore de cas golden renseignés et moteur non implémenté.'
+          : 'Moteur ASTM 53B non implémenté : ces tests seront activés une fois la formule en place.',
+    );
+  });
+}


### PR DESCRIPTION
Cette PR implémente l’Étape B du BLOC 2 (migration volumétrique ASTM 53B) :
1. Code ajouté
lib/core/volumetrics/astm53b_golden_cases.dart
Structure du dataset ASTM 53B “golden cases”
Format extensible, prêt pour calibration (Étape C)
Pas encore de valeurs définitives (placeholders)
test/core/volumetrics/astm53b_golden_test.dart
Squelette de test golden
Charge les golden cases
Prépare le futur test moteur (Étape C)
Aucun impact métier. Aucun changement sur UI, DB ou flux existants.
2. Documentation mise à jour
CHANGELOG.md : ajout entrée “golden dataset (Étape B)”
POST_PROD/00_OVERVIEW.md : progression Phase 2
11_PHASE2_TRACKER.md : Étape B cochée
RUNBOOK_VOLUMETRICS_ASTM_53B_MIGRATION.md : ajout section Étape B
3. Objectif
Préparer la calibration du moteur ASTM 53B : interpolation, formules, tolérances ±0.1 %, reproductibilité entre ML_PP et application terrain.
4. Conformité production
Aucun impact en PROD
Conforme gouvernance Phase 2
Strictement préparatoire au BLOC 2 — Étape C