### PR TITLE
BLOC 3 – Feature Flag USE_ASTM53B_15C (default OFF)

### DIFF
--- a/lib/core/feature_flags/feature_flags.dart
+++ b/lib/core/feature_flags/feature_flags.dart
@@ -1,0 +1,19 @@
+/// Feature flags centralisés.
+/// OFF par défaut pour garantir zéro impact PROD.
+class FeatureFlags {
+  final bool useAstm53b15c;
+
+  const FeatureFlags({
+    required this.useAstm53b15c,
+  });
+
+  /// Source unique: dart-define.
+  /// Activation contrôlée via:
+  /// --dart-define=USE_ASTM53B_15C=true
+  static const FeatureFlags fromEnvironment = FeatureFlags(
+    useAstm53b15c: bool.fromEnvironment(
+      'USE_ASTM53B_15C',
+      defaultValue: false,
+    ),
+  );
+}


### PR DESCRIPTION
BLOC 3 – Étape 1

Ajout du feature flag USE_ASTM53B_15C (OFF par défaut).

- Source: dart-define
- Aucune intégration métier
- Aucun impact DB
- Aucun impact UI
- Aucun impact PROD

Objectif: préparer l’intégration contrôlée ASTM 53B via feature flag.