### PR TITLE
Fix: merge BLOC3 feature flag USE_ASTM53B_15C into main

### DIFF
--- a/lib/core/feature_flags/feature_flags.dart
+++ b/lib/core/feature_flags/feature_flags.dart
@@ -1,0 +1,19 @@
+/// Feature flags centralisés.
+/// OFF par défaut pour garantir zéro impact PROD.
+class FeatureFlags {
+  final bool useAstm53b15c;
+
+  const FeatureFlags({
+    required this.useAstm53b15c,
+  });
+
+  /// Source unique: dart-define.
+  /// Activation contrôlée via:
+  /// --dart-define=USE_ASTM53B_15C=true
+  static const FeatureFlags fromEnvironment = FeatureFlags(
+    useAstm53b15c: bool.fromEnvironment(
+      'USE_ASTM53B_15C',
+      defaultValue: false,
+    ),
+  );
+}


### PR DESCRIPTION
Hotfix merge: BLOC 3 Step 1 feature flag.

Adds FeatureFlags (USE_ASTM53B_15C) default OFF.
No DB/UI/PROD impact.

Reason: previous PR #84 was not merged into main (commit d30586e only in feature branch).