### PR TITLE
BLOC 3 – Volume15C Router (Feature-Flag Switch)

### DIFF
--- a/lib/core/volumetrics/volume15c_router.dart
+++ b/lib/core/volumetrics/volume15c_router.dart
@@ -1,0 +1,31 @@
+import 'package:ml_pp_mvp/core/feature_flags/feature_flags.dart';
+import 'package:ml_pp_mvp/core/volumetrics/astm53b_engine.dart';
+
+/// Routeur central pour le calcul du volume à 15°C.
+/// OFF par défaut (legacy).
+/// ON => utilise ASTM 53B (15°C) via DefaultAstm53bCalculator.
+///
+/// ⚠️ Aucune intégration métier ici.
+double computeVolume15c({
+  required FeatureFlags flags,
+  required double volumeAmbient,
+  required double temperatureC,
+  required double densityAt15,
+}) {
+  if (!flags.useAstm53b15c) {
+    // Legacy: tant que l'intégration n'est pas branchée dans Réception,
+    // on n'altère pas le comportement.
+    return volumeAmbient;
+  }
+
+  const calculator = DefaultAstm53bCalculator();
+  final result = calculator.compute(
+    Astm53bInput(
+      densityObservedKgPerM3: densityAt15,
+      temperatureObservedC: temperatureC,
+      volumeObservedLiters: volumeAmbient,
+    ),
+  );
+
+  return result.volume15Liters;
+}

--- a/test/core/volumetrics/volume15c_router_test.dart
+++ b/test/core/volumetrics/volume15c_router_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ml_pp_mvp/core/feature_flags/feature_flags.dart';
+import 'package:ml_pp_mvp/core/volumetrics/volume15c_router.dart';
+
+void main() {
+  test('OFF -> retourne volumeAmbient (legacy)', () {
+    final result = computeVolume15c(
+      flags: const FeatureFlags(useAstm53b15c: false),
+      volumeAmbient: 1000.0,
+      temperatureC: 30.0,
+      densityAt15: 850.0,
+    );
+
+    expect(result, 1000.0);
+  });
+
+  test('ON -> utilise ASTM 53B (volume corrigé < volume ambiant à 30°C)', () {
+    final result = computeVolume15c(
+      flags: const FeatureFlags(useAstm53b15c: true),
+      volumeAmbient: 1000.0,
+      temperatureC: 30.0,
+      densityAt15: 850.0,
+    );
+
+    expect(result, lessThan(1000.0));
+  });
+}


### PR DESCRIPTION
BLOC 3 – Étape 2

Ajout du routeur computeVolume15c avec switch conditionnel via USE_ASTM53B_15C.

- OFF (default) → legacy (volumeAmbient)
- ON → ASTM 53B via DefaultAstm53bCalculator
- Aucun impact DB
- Aucune intégration dans Réception pour l’instant
- Tests unitaires OK

Prépare l’intégration contrôlée sans impact PROD.