### PR TITLE
docs(norms): adopt API MPMS 11.1 (2019) as official volumetric standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 - Backup PROD pré-migration ASTM 53B : `backups/prod_pre_astm53b_20260221_2253_data.dump`
 - Dataset ASTM 53B (BLOC 2 — Étape B) : structure des golden cases (`astm53b_golden_cases.dart`) + test golden skeleton.
 - **BLOC 3 – Étape 1 & 2 (2026-02-24)** : Feature flag `USE_ASTM53B_15C` (default OFF) ; Volume15C router (`computeVolume15c()`) avec switch ASTM 53B ; tests unitaires routeur (OFF → legacy, ON → volume corrigé). PR #86. CI verte. Controlled activation strategy.
+- Adoption officielle de la norme volumétrique API MPMS 11.1 (2019).
+- ML_PP déclaré autorité volumétrique interne.
+- Documentation normative ajoutée dans `docs/NORMES/`.
 
 ### Documentation
 - **Docs** : Reclassification industrial status after RLS hardening (PR #75, 7297c7c)
@@ -18,6 +21,10 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 - No DB impact.
 - No PROD impact (flag disabled by default).
 - No Réception wiring ; no runtime activation until explicit opt-in.
+
+### Governance (Norme volumétrique officielle — 2026-02-24)
+- Interdiction de calibration empirique du moteur volumétrique.
+- Outils tiers (ex : SEP) considérés comme indicatifs uniquement.
 
 ---
 

--- a/docs/NORMES/VOLUMETRIE_API_MPMS_11_1_2019.md
+++ b/docs/NORMES/VOLUMETRIE_API_MPMS_11_1_2019.md
@@ -1,0 +1,50 @@
+# Norme volumétrique officielle – ML_PP
+
+## Référence normative
+
+ML_PP adopte officiellement :
+
+> API MPMS Chapter 11.1 (2019 Edition)  
+> Temperature and Pressure Volume Correction Factors for Generalized Crude Oils, Refined Products, and Lubricating Oils
+
+## Portée
+
+Cette norme devient la référence volumétrique officielle interne pour :
+
+- Réceptions produit
+- Sorties produit
+- Calcul des stocks journaliers
+- KPI volumétriques
+- Toute opération impliquant une correction de volume à 15°C
+
+## Implémentation technique
+
+- Table utilisée : Table 54B (Refined Products)
+- Température de référence : 15 °C
+- Unités :
+  - Densité observée : kg/m³
+  - Température observée : °C
+  - Volume observé : Litres
+- Volume à 15°C = volumeObserved × VCF
+- Arrondi final : au litre le plus proche
+
+## Règles strictes
+
+- Aucun facteur de calibration empirique autorisé
+- Aucun alignement sur outil tiers (ex : SEP)
+- Les outils externes sont indicatifs mais non normatifs
+- Toute évolution du moteur doit référencer explicitement API MPMS 11.1 (2019)
+
+## Position stratégique
+
+ML_PP devient l'autorité volumétrique interne de Monaluxe.
+
+Les écarts avec des outils tiers ne constituent pas une anomalie si ML_PP respecte la norme API MPMS 11.1 (2019).
+
+## Gouvernance
+
+- Toute modification du moteur volumétrique nécessite :
+  - PR dédiée
+  - Validation technique
+  - Mise à jour documentation
+  - Journalisation post-production

--- a/docs/POST_PROD/09_PHASE2_STRATEGIE.md
+++ b/docs/POST_PROD/09_PHASE2_STRATEGIE.md
@@ -92,6 +92,17 @@ La Phase 2 est validée comme priorité post-PROD. Exécution progressive, docum
 
 ---
 
+## Décision stratégique – Norme volumétrique officielle
+
+**Date** : 24 février 2026  
+**Décision** : Adoption API MPMS 11.1 (2019)
+
+- ML_PP devient autorité volumétrique interne ; fin de dépendance aux outils tiers comme référence normative.
+- Référence documentée : `docs/NORMES/VOLUMETRIE_API_MPMS_11_1_2019.md`.
+- Migration progressive des calculs historiques si nécessaire ; toute correction future devra être tracée et auditée.
+
+---
+
 ## Règles de non-régression
 
 - **GO PROD** : Les flux métier actuellement en production (réceptions, sorties, stocks, dashboard, cours de route) ne doivent pas être modifiés fonctionnellement.

--- a/docs/POST_PROD/10_PHASE2_PLAN_10_ACTIONS.md
+++ b/docs/POST_PROD/10_PHASE2_PLAN_10_ACTIONS.md
@@ -165,6 +165,17 @@
 
 ---
 
+## Décision stratégique – Norme volumétrique officielle
+
+**Date** : 24 février 2026  
+**Décision** : Adoption API MPMS 11.1 (2019)
+
+- ML_PP déclaré autorité volumétrique ; les actions et évolutions du moteur volumétrique s’alignent sur la norme (Table 54B, 15°C, arrondi au litre).
+- Aucune calibration empirique ni alignement sur outil tiers autorisé.
+- Migration progressive des calculs historiques si nécessaire ; toute évolution du moteur doit être tracée et documentée.
+
+---
+
 ## Interdictions
 
 - **lib/** : interdiction levée pour Action 4 validée.

--- a/docs/POST_PROD/11_PHASE2_TRACKER.md
+++ b/docs/POST_PROD/11_PHASE2_TRACKER.md
@@ -127,6 +127,15 @@
 
 ---
 
+## Décision stratégique – Norme volumétrique officielle (2026-02-24)
+
+- **Date** : 24 février 2026. **Décision** : Adoption API MPMS 11.1 (2019).
+- ML_PP devient autorité volumétrique interne ; fin de dépendance normative aux outils tiers.
+- Migration progressive des calculs historiques si nécessaire ; toute correction future tracée et auditée.
+- Référence : `docs/NORMES/VOLUMETRIE_API_MPMS_11_1_2019.md`.
+
+---
+
 ## Checkpoint actuel
 
 Phase 2 : Action 1 (v_integrity_checks) DONE ; Action 2 (system_alerts + workflow ACK/RESOLVE) **DONE (PROD)** ; Action 4 (Écran intégrité système) DONE ; Action 7 (Audit RLS + hardening) DONE. Table `public.system_alerts` déployée avec trigger actor. UI Integrity Checks avec boutons ACK/RESOLVE en exploitation sur https://monaluxe.app. Dette technique documentée dans `docs/POST_PROD/PHASE2_TECH_DEBT.md`.

--- a/docs/POST_PROD/12_PHASE2_PROD_DEPLOY_LOG.md
+++ b/docs/POST_PROD/12_PHASE2_PROD_DEPLOY_LOG.md
@@ -165,3 +165,18 @@ If a legitimate use case requires a public policy (rare): recreate the policy wi
 - No DB migration.
 - No runtime activation (flag disabled by default).
 - PR #86. Controlled activation strategy.
+
+---
+
+# Entry 5 — Décision stratégique – Norme volumétrique officielle (documentation) — 2026-02-24
+
+## 1. Metadata
+- **Date (UTC)** : 2026-02-24
+- **Environment** : N/A (documentation only, no deploy)
+- **Change ID** : Norme-Volumetrie-API-MPMS-11.1-2019
+
+## 2. Change Description
+- **Décision** : Adoption officielle API MPMS 11.1 (2019). ML_PP devient autorité volumétrique interne.
+- Fin de dépendance aux outils tiers comme référence normative ; migration progressive des calculs historiques si nécessaire.
+- Documentation normative : `docs/NORMES/VOLUMETRIE_API_MPMS_11_1_2019.md`.
+- Aucune modification moteur, logique ou PROD ; PR purement documentaire. Toute correction future devra être tracée et auditée.


### PR DESCRIPTION
Official adoption of API MPMS Chapter 11.1 (2019) as the volumetric standard for ML_PP.

- ML_PP declared internal volumetric authority
- No empirical calibration allowed
- SEP considered indicative only
- Documentation added under docs/NORMES/
- POST_PROD documentation updated
- CHANGELOG updated

No code changes.
No production impact.
Documentation-only PR.