### PR TITLE
docs(astm): document lookup-grid domain guard and staging sorties mig…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 
 ## [Unreleased]
 
+### Changed
+
+**Volumetric engine alignment (STAGING)**
+
+- sorties_produit migrated from golden engine to lookup-grid
+- new trigger `trg_02_sorties_compute_lookup_15c`
+- new function `sorties_compute_15c_before_ins_lookup`
+- corrected trigger execution order
+- volume 15°C convention standardized to **integer liters**
+- smoke test validated (1000 L → 997 L)
+- snapshot and logs verified
+- documented out-of-domain validation for lookup-grid volumetric engine
+- added centralized lookup-grid domain guard in STAGING
+- added `astm.lookup_grid_domain(...)`
+- added `astm.assert_lookup_grid_domain(...)`
+- wired centralized domain validation into receptions and sorties lookup-grid triggers
+- validated batch domain: density `820-860`, temperature `10-40`, `63` rows
+- validated standardized out-of-domain error handling (`ASTM_LOOKUP_OUT_OF_DOMAIN_DENS`)
+- no PROD migration executed
+
+*Note : PROD database unchanged.*
+
+---
+
 ### 📄 Investigation volumétrique STAGING / PROD (2026-03-07) — NO-GO migration PROD
 - **Audit PROD** : Backup complet `backups/ml_pp_prod_J0_pre_volumetric_engine.dump` (pg_restore --list OK). Comptages : receptions=8, sorties_produit=0, stocks_journaliers=3, stocks_snapshot=2. Schéma ASTM et triggers volumétriques absents en PROD.
 - **Audit STAGING** : Deux moteurs identifiés — Golden engine (astm_golden_cases_15c, 8 lignes, domaine 836–837,6 / 19–29,7) et Lookup-grid engine (astm_lookup_grid_15c, 63 lignes, 820–860 / 10–40). Réceptions branchées sur lookup-grid ; sorties sur golden → STAGING hybride.

--- a/docs/POST_PROD/ASTM/2026-03-07_INVESTIGATION_STAGING_PROD_VOLUMETRIC_ALIGNMENT.md
+++ b/docs/POST_PROD/ASTM/2026-03-07_INVESTIGATION_STAGING_PROD_VOLUMETRIC_ALIGNMENT.md
@@ -1,265 +1,410 @@
-# Investigation technique — Alignement volumétrique STAGING / PROD (7 mars 2026)
+# Investigation — Volumetric Engine Alignment (STAGING vs PROD)
 
 **Date** : 2026-03-07  
-**Périmètre** : Audit STAGING et PROD — moteurs volumétriques, triggers, schéma.  
-**Résultat** : **NO-GO migration PROD immédiate** — STAGING non homogène.  
-**Nature** : Documentation uniquement — aucune migration PROD exécutée, aucune fonction SQL modifiée, aucune logique métier modifiée.
+**Périmètre** : Audit PROD et STAGING, décision technique, migration STAGING sorties vers lookup-grid.  
+**Résultat** : STAGING homogène (lookup-grid unique). Migration PROD **non exécutée**.
 
 ---
 
-## 1. Objectif
+## 1. Contexte
 
-L’investigation du 7 mars 2026 avait pour but de :
+Le projet **ML_PP MVP** (Monaluxe Petrol Platform) est un ERP pétrolier industriel utilisant Flutter Web et Supabase Postgres. Le **calcul volumétrique carburant** (conversion vers volume standard à 15°C) est un point critique métier : il impacte les réceptions, les sorties, les stocks et la traçabilité. L’alignement avec la norme **API MPMS 11.1 / ASTM Table 53B** vise une conformité industrielle et une cohérence avec les références terrain.
 
-- Préparer une migration volumétrique PROD ;
-- Vérifier l’état STAGING (moteurs, triggers, données) ;
-- Comparer les moteurs ASTM présents en STAGING ;
-- Confirmer la cible technique finale ;
-- Identifier les écarts STAGING / PROD ;
-- Décider si la migration PROD devait être lancée.
+En amont de l’investigation, des **écarts terrain** de l’ordre de **~50 à 70 L** avaient été constatés entre les volumes calculés par l’application et les références (ex. outil SEP ou oracle terrain), liés notamment à la sémantique des densités (densité observée vs densité à 15°C) et à un calcul non centralisé côté base.
 
-**Conclusion** : La migration PROD ne doit pas être lancée. STAGING n’est pas encore homogène (deux moteurs distincts : réceptions = lookup-grid, sorties = golden).
+L’objectif de l’investigation et des corrections STAGING est de **stabiliser le moteur volumétrique côté DB** (triggers, fonctions ASTM, convention litre entier) avant toute migration PROD.
 
 ---
 
-## 2. Méthode d’investigation
+## 2. Audit PROD
 
-- Audit PROD : backup complet, vérification `pg_restore --list`, comptages des tables métier, présence du schéma ASTM et des objets volumétriques.
-- Audit STAGING : identification des moteurs volumétriques (golden engine vs lookup-grid engine), objets DB associés, branchement réel des triggers sur `receptions` et `sorties_produit`.
-- Analyse des triggers : ordre d’exécution, fonction appelée par chaque trigger.
-- Comparaison schéma : colonnes présentes en STAGING vs PROD pour `receptions` et `sorties_produit`.
-- Tests comparatifs : même entrée (volume, densité, température) passée au moteur golden et au moteur lookup-grid ; comparaison des résultats.
-- Décision : GO / NO-GO migration PROD, décision intermédiaire (moteur cible unique), prochaines étapes.
+### Backup réalisé
 
----
-
-## 3. Audit PROD
-
-L’audit PROD a été réalisé avec succès.
-
-### Backup
-
-- **Backup complet effectué** : `backups/ml_pp_prod_J0_pre_volumetric_engine.dump`
+- **Fichier** : `backups/ml_pp_prod_J0_pre_volumetric_engine.dump`
 - **Vérification** : `pg_restore --list` OK
 
-### Comptages PROD
+### Résultats audit
 
-| Table              | Comptage |
-|--------------------|----------|
-| receptions         | 8        |
-| sorties_produit    | 0        |
-| stocks_journaliers| 3        |
-| stocks_snapshot    | 2        |
+| table              | rows |
+|--------------------|------|
+| receptions         | 8    |
+| sorties_produit    | 0    |
+| stocks_journaliers | 3    |
+| stocks_snapshot    | 2    |
 
-### Schéma ASTM
+### Observations
 
-- **Schéma ASTM** : absent en PROD.
+- Schéma **`astm`** absent en PROD.
+- Aucun trigger volumétrique actif en PROD.
+- Colonne **`volume_15c`** : NULL sur les réceptions existantes.
+- L’ancien pipeline utilisait **`volume_corrige_15c`** uniquement.
 
-### Tables
+### Conclusion
 
-- **astm_golden_cases_15c** : absente en PROD.
-
-### Triggers volumétriques ASTM
-
-- **Triggers volumétriques ASTM** : absents en PROD.
-
-### Tables métier PROD
-
-- **Immutabilité** : UPDATE / DELETE interdits sur les tables métier concernées.
+PROD est **stable et figé**. Aucune migration volumétrique n’a été exécutée sur la base PROD.
 
 ---
 
-## 4. Données historiques PROD
-
-Sur les **8 réceptions** PROD :
-
-- **Colonnes observées** : `volume_ambiant`, `temperature_ambiante_c`, `densite_a_15`, `volume_corrige_15c`.
-- **volume_15c** : NULL.
-
-**Interprétation** : L’ancien pipeline utilisait `volume_corrige_15c` uniquement. La colonne `volume_15c` n’était pas utilisée.
-
----
-
-## 5. Audit STAGING — Moteurs volumétriques
+## 3. Investigation STAGING
 
 Deux moteurs volumétriques distincts ont été identifiés en STAGING.
 
-### Moteur 1 — Golden engine
+### Golden Engine
 
-**Objets** :
+**Tables**
 
 - `public.astm_golden_cases_15c`
+
+**Fonctions**
+
 - `astm.ctl_from_golden`
 - `astm.compute_15c_from_golden`
 - `astm.fn_sortie_compute_golden_15c`
 
-**Domaine du golden dataset** :
+**Domaine**
 
 - Densité : 836 → 837,6 kg/m³
 - Température : 19 → 29,7 °C
-- **Nombre de lignes** : 8
+- **rows** : 8
 
-**Problème** : Domaine trop étroit. Certaines densités observées terrain (839 → 843) ne sont pas couvertes.
+**Limite**
+
+- Dataset trop restreint : certaines densités observées terrain (839 → 843) ne sont pas couvertes.
 
 ---
 
-### Moteur 2 — Lookup-grid engine
+### Lookup Grid Engine
 
-**Objets** :
+**Tables**
 
 - `public.astm_lookup_grid_15c`
+
+**Fonctions**
+
 - `astm.lookup_15c_exact`
 - `astm.lookup_15c_bilinear`
 - `astm.lookup_15c_bilinear_v2`
 - `astm.compute_v15_from_lookup_grid`
 
-**Batch actif** :
+**Batch actif**
 
-- `source = ASTM_OFFICIAL_APP`
-- `produit_code = GASOIL`
-- `method_version = API_MPMS_11_1`
-- `batch_id = GASOIL_P0_2026-02-28`
+- `GASOIL_P0_2026-02-28` (source ASTM_OFFICIAL_APP, produit_code GASOIL, method_version API_MPMS_11_1)
 
-**Domaine couvert** :
+**Domaine**
 
 - Densité : 820 → 860 kg/m³
 - Température : 10 → 40 °C
+- **rows** : 63
 
-**Grille** :
+**Conclusion**
 
-- **Densités** : 820, 825, 830, 835, 840, 845, 850, 855, 860
-- **Températures** : 10, 15, 20, 22, 25, 30, 40
-- **Total lignes** : 63
-
-La grille est régulière et complète.
+- Le lookup-grid couvre l’ensemble du domaine opérationnel et est plus robuste pour la production.
 
 ---
 
-## 6. Branchement réel STAGING
+## 4. Branchement STAGING avant correction
 
-### Réceptions
+**Réceptions** : branchées sur le **lookup-grid** (trigger `receptions_compute_15c_before_ins`, fonction `astm.compute_v15_from_lookup_grid`).
 
-- **Trigger** : `public.receptions_compute_15c_before_ins`
-- **Fonction utilisée** : `astm.compute_v15_from_lookup_grid`
-- **Conclusion** : Réceptions = **lookup-grid**.
+**Sorties** : branchées sur le **golden engine** (trigger `trg_00_sorties_compute_golden_15c`, fonction `astm.fn_sortie_compute_golden_15c`).
 
-### Sorties
+**Conclusion**
 
-- **Trigger** : `trg_00_sorties_compute_golden_15c`
-- **Fonction utilisée** : `astm.compute_15c_from_golden`
-- **Conclusion** : Sorties = **golden**.
-
-### Synthèse
-
-**STAGING est hybride** :
-
-- **Réceptions** → lookup-grid
-- **Sorties** → golden
+- STAGING était **hybride** (réceptions = lookup-grid, sorties = golden).
+- Décision : **NO-GO PROD** tant que STAGING n’est pas homogène.
 
 ---
 
-## 7. Analyse des triggers (sorties)
+## 5. Test comparatif moteurs
 
-### Ordre actuel des triggers sur sorties_produit
+**Entrée commune**
+
+- volume = 1000 L  
+- densité = 837 kg/m³  
+- température = 19 °C  
+
+**Résultat Golden** : 997 L  
+
+**Résultat Lookup-grid** : 996,6 L  
+
+**Écart** : ≈ 0,4 L  
+
+**Conclusion** : Les deux moteurs sont cohérents. Le lookup-grid est retenu comme moteur unique pour homogénéiser STAGING.
+
+---
+
+## 6. Problème d’ordre de triggers
+
+**Ordre initial (sorties)**
 
 1. `trg_00_sorties_compute_golden_15c`
 2. `trg_00_sorties_set_created_by`
 3. `trg_01_sorties_set_volume_ambiant`
-4. `trg_sorties_check_produit_citerne`
-5. `trg_sortie_before_ins`
-6. `trg_sorties_after_insert`
+4. …
 
-**Problème** : Le calcul volumétrique est exécuté **avant** le calcul de `volume_ambiant`. Le trigger `trg_00_sorties_compute_golden_15c` s’exécute en premier, alors que `volume_ambiant` est calculé par `trg_01_sorties_set_volume_ambiant`.
+**Problème**
 
-### Ordre recommandé
+- Le calcul volumétrique était exécuté **avant** le calcul du volume ambiant. Le trigger volumétrique s’exécutait en premier, alors que `volume_ambiant` est calculé par `trg_01_sorties_set_volume_ambiant`, ce qui pouvait conduire à des incohérences ou à une dépendance incorrecte aux valeurs déjà présentes en entrée.
 
-1. `trg_00_sorties_set_created_by`
-2. `trg_01_sorties_set_volume_ambiant`
-3. `trg_02_sorties_compute_lookup_15c` (calcul volumétrique après volume_ambiant)
-4. `trg_sorties_check_produit_citerne`
-5. `trg_sortie_before_ins`
-6. `trg_sorties_after_insert`
+**Correction**
+
+- Réordonnancement : le trigger de calcul 15°C doit s’exécuter **après** `trg_01_sorties_set_volume_ambiant` (nouveau trigger `trg_02_sorties_compute_lookup_15c`).
 
 ---
 
-## 8. Différence schéma STAGING / PROD
+## 7. Décision technique
 
-### Réceptions
+**Cible**
 
-**STAGING possède, PROD ne possède pas** :
+- **Lookup-grid** pour :
+  - réceptions (déjà en place)
+  - sorties (à migrer)
 
-- `densite_observee_kgm3`
-- `densite_a_15_kgm3`
-- `densite_a_15_g_cm3`
+**Golden engine**
 
-### Sorties
-
-**STAGING possède, PROD ne possède pas** :
-
-- `densite_a_15_kgm3`
-- `densite_a_15_g_cm3`
+- Conservé comme **outil de validation uniquement**, pas comme moteur de production pour les écritures.
 
 ---
 
-## 9. Tests comparatifs
+## 8. Migration STAGING exécutée le 7 mars 2026
 
-### Test golden
+**Actions réalisées**
 
-- **Entrée** : volume = 1000 L, densité = 837 kg/m³, température = 19 °C
-- **Résultat** : `volume_corrige_15c = 997` L
+- Suppression du trigger golden sorties :  
+  `DROP TRIGGER IF EXISTS trg_00_sorties_compute_golden_15c ON public.sorties_produit;`
+- Création de la fonction :  
+  `public.sorties_compute_15c_before_ins_lookup()`  
+  (BEFORE INSERT ; lecture `app_settings.env` avec blocage hors STAGING ; garantie de `volume_ambiant` ; exigence de `temperature_ambiante_c` ; utilisation de `new.densite_a_15_kgm3` comme entrée legacy / densité observée ; appel à `astm.compute_v15_from_lookup_grid(...)` ; écriture de `volume_corrige_15c`, `densite_a_15_kgm3`, `densite_a_15_g_cm3`).
+- Création du trigger :  
+  `trg_02_sorties_compute_lookup_15c`  
+  (BEFORE INSERT sur `public.sorties_produit`, exécution après `trg_01_sorties_set_volume_ambiant` pour respecter l’ordre voulu).
 
-### Test lookup-grid
+**Convention retenue**
 
-- **Résultats observés** : `densite_a_15_kgm3 = 839,7`, VCF = 0,9966, `volume_15c = 996,6` L
-
-### Écart entre les deux moteurs
-
-- **Écart** : ≈ 0,4 L (997 vs 996,6).
-- **Conclusion** : Les deux moteurs sont cohérents. Le lookup-grid est plus robuste (domaine plus large, grille régulière).
-
----
-
-## 10. Analyse technique
-
-- **Homogénéité STAGING** : STAGING utilise deux moteurs différents selon la table (réceptions vs sorties). Pour une migration PROD maîtrisée et un comportement déterministe, un **moteur unique** est requis.
-- **Cible technique retenue** : **Lookup-grid engine** comme moteur unique pour réceptions et sorties. Domaine 820–860 kg/m³ et 10–40 °C couvre les densités terrain observées (839–843).
-- **Golden engine** : À conserver comme **outil de validation uniquement**, pas comme moteur en production.
-- **Ordre des triggers sorties** : L’ordre actuel exécute le calcul volumétrique avant la mise à jour de `volume_ambiant` ; un réordonnancement (calcul volumétrique après `volume_ambiant`) est recommandé pour cohérence et maintenabilité.
-- **Écart schéma** : PROD devra recevoir les colonnes volumétriques (`densite_observee_kgm3`, `densite_a_15_kgm3`, `densite_a_15_g_cm3` sur réceptions ; `densite_a_15_kgm3`, `densite_a_15_g_cm3` sur sorties) et le schéma ASTM (lookup-grid) dans le cadre d’une migration documentée et validée.
+- Volume 15°C = **litre entier** (aligné réceptions et comportement historique sorties).  
+  `new.volume_corrige_15c := round(r.volume_15c_l);`
 
 ---
 
-## 11. Décision
+## Centralized lookup-grid domain guard
 
-### NO-GO migration PROD immédiate
+Après la migration STAGING des sorties vers le lookup-grid (section 8), une amélioration de robustesse a été introduite : un **garde-fou centralisé du domaine** du batch lookup-grid, branché sur les triggers réceptions et sorties.
 
-**Raison** : STAGING non homogène. Moteurs volumétriques différents selon la table (réceptions = lookup-grid, sorties = golden). La migration PROD ne doit pas être lancée tant que STAGING n’est pas aligné sur un moteur unique et revalidé.
+### a) Pourquoi ce garde-fou a été ajouté
 
-### Décision intermédiaire
+- Le moteur lookup-grid fonctionnait déjà (réceptions et sorties) et rejetait correctement les entrées hors domaine via la fonction d’interpolation (ex. `ASTM_BILINEAR_OUT_OF_DOMAIN_DENS`).
+- Le contrôle du domaine restait toutefois **implicite** : il était réalisé à l’intérieur de la fonction de calcul (`astm.compute_v15_from_lookup_grid` ou les sous-fonctions de lookup), sans lecture centralisée des bornes du batch.
+- Un garde-fou **centralisé** améliore :
+  - **lisibilité** : une seule source de vérité pour le domaine du batch actif
+  - **stabilité des erreurs** : messages d’erreur homogènes et explicites (produit, source, method, batch, borne dépassée)
+  - **maintenabilité** : évolution du domaine (nouveau batch, extension de grille) sans disperser la logique dans les triggers
+  - **réutilisabilité** : les triggers réceptions et sorties appellent la même assertion avant le calcul
 
-- **Objectif cible** : **Lookup-grid engine unique** pour réceptions **et** sorties.
-- **Golden engine** : Outil de validation uniquement, pas moteur de production.
+### b) Les deux fonctions ajoutées
+
+**`astm.lookup_grid_domain(p_produit_code text, p_source text, p_method_version text, p_batch_id text)`**
+
+- **But** : Retourner les bornes du domaine du batch lookup-grid actif (lecture centralisée à partir de la table `astm_lookup_grid_15c`).
+- **Inputs** : `p_produit_code`, `p_source`, `p_method_version`, `p_batch_id` (ex. GASOIL, ASTM_OFFICIAL_APP, API_MPMS_11_1, GASOIL_P0_2026-02-28).
+- **Outputs** : `dens_min`, `dens_max`, `temp_min`, `temp_max`, `rows_count`.
+- **Intérêt architectural** : Point d’entrée unique pour connaître le domaine opérationnel du batch ; utilisable en diagnostic, tests et par la fonction d’assertion.
+
+**`astm.assert_lookup_grid_domain(p_produit_code text, p_source text, p_method_version text, p_batch_id text, p_temperature_c double precision, p_densite_observee_kgm3 double precision)`**
+
+- **But** : Vérifier qu’un couple (température, densité observée) est dans le domaine du batch actif ; lever une erreur claire si hors domaine.
+- **Inputs** : identifiants du batch (produit_code, source, method_version, batch_id) + `p_temperature_c`, `p_densite_observee_kgm3`.
+- **Comportement** : lit le domaine via la logique du batch (ou appelle `lookup_grid_domain`), compare les valeurs ; en cas de sortie de domaine, lève une exception avec message standardisé (ex. `ASTM_LOOKUP_OUT_OF_DOMAIN_DENS`).
+- **Intérêt architectural** : Les triggers n’ont plus à dupliquer la logique de contrôle ; ils appellent `assert_lookup_grid_domain` avant `compute_v15_from_lookup_grid`, ce qui évite d’appeler le moteur avec des valeurs impossibles.
+
+### c) Branchement sur réceptions et sorties
+
+- **`public.receptions_compute_15c_before_ins()`** : appelle désormais **`astm.assert_lookup_grid_domain(...)`** (avec les paramètres du batch actif et les champs température / densité observée de `NEW`) **avant** **`astm.compute_v15_from_lookup_grid(...)`**. En cas de hors domaine, l’INSERT est rejeté avec l’erreur centralisée.
+- **`public.sorties_compute_15c_before_ins_lookup()`** : fait de même : appel à **`astm.assert_lookup_grid_domain(...)`** avant **`astm.compute_v15_from_lookup_grid(...)`**, avec les mêmes identifiants de batch (GASOIL, ASTM_OFFICIAL_APP, API_MPMS_11_1, GASOIL_P0_2026-02-28).
+
+Réceptions et sorties partagent ainsi la même logique de validation de domaine.
+
+### d) Domaine confirmé
+
+Pour le batch actif **GASOIL_P0_2026-02-28** (produit_code GASOIL, source ASTM_OFFICIAL_APP, method_version API_MPMS_11_1), le domain guard confirme :
+
+- **Densité (observée)** : 820 → 860 kg/m³  
+- **Température** : 10 → 40 °C  
+- **rows_count** : 63  
+
+(Valeurs obtenues via `select * from astm.lookup_grid_domain(...)`.)
+
+### e) Test hors domaine
+
+Un test volontairement hors domaine a été exécuté :
+
+- **Entrée** : densité observée = **900** kg/m³, température = 19 °C, batch GASOIL lookup-grid.
+- **Résultat attendu et obtenu** : rejet de l’INSERT avec erreur centralisée.
+
+**Message d’erreur obtenu**
+
+```
+ASTM_LOOKUP_OUT_OF_DOMAIN_DENS: produit=GASOIL source=ASTM_OFFICIAL_APP method=API_MPMS_11_1 batch=GASOIL_P0_2026-02-28 dens=900 outside [820,860]
+```
+
+Le garde-fou centralisé fournit un message explicite (produit, source, method, batch, valeur et borne), ce qui facilite le diagnostic et l’extension éventuelle de la grille.
+
+### f) Conclusion
+
+- Le moteur lookup-grid STAGING est maintenant **protégé par un garde-fou centralisé** : lecture du domaine et assertion avant calcul sont déléguées à `astm.lookup_grid_domain` et `astm.assert_lookup_grid_domain`.
+- **Réceptions** et **sorties** partagent la même logique de validation de domaine ; les erreurs hors domaine sont standardisées.
+- **Aucune migration PROD n’a été exécutée** : cette évolution concerne uniquement STAGING.
 
 ---
 
-## 12. Prochaines étapes
+## 9. Validation fonctionnelle
 
-1. **Basculer les sorties STAGING** vers `astm.compute_v15_from_lookup_grid` (remplacer l’usage du golden engine par le lookup-grid pour les sorties).
-2. **Revalider STAGING** : vérifier réceptions et sorties avec le même moteur (lookup-grid), contrôler ordre des triggers et cohérence des volumes.
-3. **Préparer la migration PROD** : une fois STAGING homogène et revalidé, mettre à jour le runbook PROD, la checklist et la stratégie d’intervention (schéma, colonnes, backup, fenêtre).
+**Smoke test**
+
+- **sortie_id** : `0eaa2cc8-5ccc-484d-9358-5176f698ec7e`
+
+**Entrée**
+
+- volume = 1000 L  
+- température = 19 °C  
+- densité (observée) = 837 kg/m³  
+
+**Résultat**
+
+- **volume_corrige_15c** = 997 L  
+- **Densité à 15°C** : 839,7 kg/m³  
+
+La sortie a été créée et validée ; le trigger lookup-grid calcule correctement le volume à 15°C et la densité dérivée.
 
 ---
 
-## Confirmation — Documentation uniquement
+## 10. Validation hors domaine (lookup-grid)
 
-Ce document atteste que :
+Afin de confirmer la robustesse du moteur volumétrique lookup-grid, un test volontairement **hors domaine ASTM** a été exécuté.
 
-- **Aucune migration PROD** n’a été exécutée à l’issue de cette investigation.
-- **Aucune fonction SQL** n’a été modifiée.
-- **Aucune logique métier** n’a été modifiée.
-- **Seule la documentation** a été créée ou mise à jour (ce fichier et les références listées dans le CHANGELOG et les runbooks).
+**Entrée utilisée**
+
+- volume_ambiant = 1000  
+- temperature_c = 19  
+- densite_observee_kgm3 = 900  
+
+Cette densité est volontairement hors du domaine couvert par la grille lookup-grid.
+
+**Domaine lookup-grid actuel**
+
+- densité : 820 → 860  
+- température : 10 → 40  
+
+**Requête exécutée**
+
+```sql
+insert into public.sorties_produit (
+  citerne_id,
+  produit_id,
+  client_id,
+  index_avant,
+  index_apres,
+  temperature_ambiante_c,
+  densite_a_15_kgm3,
+  proprietaire_type,
+  statut,
+  date_sortie,
+  note
+)
+values (
+  '57da330a-1305-4582-be45-ceab0f1aa795',
+  '22222222-2222-2222-2222-222222222222',
+  '8ad6ef76-e45c-4159-a145-62df52563881',
+  0,
+  1000,
+  19,
+  900,
+  'MONALUXE',
+  'validee',
+  now(),
+  'SMOKE_TEST_LOOKUP_SORTIE_OUT_OF_DOMAIN_DENS_2026_03_07'
+);
+```
+
+**Résultat**
+
+- **ERROR** : `SORTIE_VOLUMETRICS_FAILED`  
+- **Cause** : `ASTM_BILINEAR_OUT_OF_DOMAIN_DENS: dens=900`
+
+**Message complet**
+
+```
+SORTIE_VOLUMETRICS_FAILED: cannot compute Volume@15 using LOOKUP-GRID engine.
+Inputs: volume_ambiant=1000, densite_obs_kgm3=900, temp_c=19.
+Cause: ASTM_BILINEAR_OUT_OF_DOMAIN_DENS: dens=900.
+Action: ensure (temp,dens) is inside lookup grid domain (or expand the grid), then retry.
+```
+
+**Conclusion**
+
+Le moteur lookup-grid rejette correctement toute entrée hors domaine et fournit un message d’erreur explicite permettant :
+
+- d’identifier immédiatement la cause  
+- de corriger les données terrain  
+- ou d’étendre la grille ASTM si nécessaire  
+
+Ce comportement est conforme aux attentes pour un moteur volumétrique industriel.
 
 ---
 
-**Document créé** : 2026-03-07  
-**Référence** : Investigation technique — Alignement volumétrique STAGING / PROD.
+## 11. Validation pipeline aval
+
+**Snapshot avant sortie**
+
+- Stock (ambiant / 15°C) : 144753 / 144057,63
+
+**Snapshot après sortie validée**
+
+- Stock : 143753 / 143060,63
+
+**Débit confirmé**
+
+- −1000 L ambiant  
+- −997 L @15°C  
+
+**Log enregistré**
+
+- `SORTIE_VALIDE` (ou équivalent) présent dans `log_actions` avec les détails attendus (volume_15c, citerne, etc.).
+
+**Conclusion**
+
+- Pipeline complet OK : snapshot, stocks et logs sont cohérents avec la sortie validée.
+
+---
+
+## 12. État final STAGING
+
+- **Réceptions** : lookup-grid  
+- **Sorties** : lookup-grid  
+
+**Golden engine**
+
+- Utilisé en **validation uniquement** (tests, comparaisons), pas pour les écritures métier.
+
+**Conclusion**
+
+- STAGING est maintenant **homogène** (moteur unique lookup-grid pour réceptions et sorties).
+
+---
+
+## 13. Suite
+
+**Avant migration PROD**
+
+- Documentation complète (ce document, runbook STAGING, checklist ASTM, runbook migration PROD).
+- Checklist ASTM à jour (STAGING homogène, backup PROD, etc.).
+- Runbook migration PROD à jour (préconditions, procédure, rollback).
+- Préparation du schéma PROD (colonnes volumétriques, schéma ASTM, triggers) dans le cadre d’une release planifiée.
+
+**Migration PROD**
+
+- **Non exécutée.** La base PROD n’a pas été modifiée. Toute migration PROD fera l’objet d’une procédure dédiée, d’un backup validé et d’une fenêtre d’intervention formalisée.
+
+---
+
+**Document mis à jour** : 2026-03-07  
+**Référence** : Investigation — Volumetric Engine Alignment (STAGING vs PROD) + migration STAGING sorties lookup-grid.

--- a/docs/POST_PROD/ASTM/RUNBOOK_STAGING_SORTIES_LOOKUP_GRID_MIGRATION.md
+++ b/docs/POST_PROD/ASTM/RUNBOOK_STAGING_SORTIES_LOOKUP_GRID_MIGRATION.md
@@ -1,0 +1,219 @@
+# Runbook — STAGING Sorties Lookup Grid Migration
+
+**Date** : 2026-03-07  
+**Périmètre** : STAGING uniquement  
+**Objectif** : Documenter la migration des sorties du moteur golden vers le moteur lookup-grid pour homogénéiser STAGING.
+
+---
+
+## 1. Objectif
+
+Corriger l’**incohérence STAGING** : les réceptions utilisaient le moteur lookup-grid tandis que les sorties utilisaient le moteur golden, ce qui rendait l’environnement hybride et bloquait toute décision GO pour la migration PROD. La migration documentée ici aligne les sorties sur le même moteur que les réceptions (lookup-grid).
+
+---
+
+## 2. Contexte
+
+- **Réceptions** : déjà branchées sur le **lookup-grid** (trigger `receptions_compute_15c_before_ins`, fonction `astm.compute_v15_from_lookup_grid`).
+- **Sorties** : avant migration, branchées sur le **golden engine** (trigger `trg_00_sorties_compute_golden_15c`, fonction `astm.fn_sortie_compute_golden_15c`).
+
+Conséquence : STAGING hybride → NO-GO migration PROD tant que les sorties n’étaient pas migrées vers le lookup-grid.
+
+---
+
+## 3. Préconditions
+
+- **Environnement** : `public.app_settings` doit contenir `key = 'env'` et `value = 'staging'`. Hors STAGING, le nouveau trigger bloque l’INSERT.
+- **Batch lookup-grid** : La table `public.astm_lookup_grid_15c` doit contenir le batch actif `GASOIL_P0_2026-02-28` (source ASTM_OFFICIAL_APP, produit_code GASOIL, method_version API_MPMS_11_1) avec une grille couvrant le domaine opérationnel (densité 820–860, température 10–40).
+- **Schéma** : Colonnes `densite_a_15_kgm3`, `densite_a_15_g_cm3`, `volume_corrige_15c`, `volume_ambiant`, `temperature_ambiante_c` présentes sur `public.sorties_produit`.
+
+---
+
+## 4. Investigation
+
+L’investigation du 7 mars 2026 a établi :
+
+- Deux moteurs en STAGING : golden (domaine restreint, 8 lignes) et lookup-grid (63 lignes, domaine 820–860 / 10–40).
+- Réceptions = lookup-grid, sorties = golden → STAGING hybride.
+- Test comparatif (1000 L, 837 kg/m³, 19 °C) : golden 997 L, lookup-grid 996,6 L — écart ≈ 0,4 L, moteurs cohérents.
+- Ordre des triggers sorties : le calcul volumétrique s’exécutait avant le calcul de `volume_ambiant` ; ordre corrigé en plaçant le nouveau trigger **après** `trg_01_sorties_set_volume_ambiant`.
+
+Référence : `docs/POST_PROD/ASTM/2026-03-07_INVESTIGATION_STAGING_PROD_VOLUMETRIC_ALIGNMENT.md`.
+
+---
+
+## 5. Décision
+
+- **Cible** : Lookup-grid pour les sorties (comme pour les réceptions).
+- **Convention** : Volume 15°C en **litre entier** : `new.volume_corrige_15c := round(r.volume_15c_l)`.
+- **Sémantique** : `sorties_produit.densite_a_15_kgm3` est utilisé en **entrée** comme densité observée (legacy) ; le trigger calcule et réécrit la densité à 15°C et le volume corrigé.
+
+---
+
+## 6. SQL appliqué
+
+Le script suivant a été exécuté en STAGING le 7 mars 2026. Il est fourni à titre de documentation ; ne pas l’exécuter en PROD sans procédure validée.
+
+```sql
+-- =============================================================================
+-- STAGING ONLY — Migration sorties : golden → lookup-grid
+-- Date : 2026-03-07
+-- =============================================================================
+
+-- 1) Suppression de l'ancien trigger golden
+DROP TRIGGER IF EXISTS trg_00_sorties_compute_golden_15c ON public.sorties_produit;
+
+-- 2) Création de la fonction BEFORE INSERT pour sorties (lookup-grid)
+CREATE OR REPLACE FUNCTION public.sorties_compute_15c_before_ins_lookup()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_env text;
+  v_volume_ambiant double precision;
+  v_temp double precision;
+  v_density_obs double precision;
+  r record;
+BEGIN
+  -- Garde-fou : STAGING uniquement
+  SELECT value INTO v_env FROM public.app_settings WHERE key = 'env';
+  IF COALESCE(v_env, '') <> 'staging' THEN
+    RAISE EXCEPTION 'SORTIE_VOLUMETRICS_BLOCKED: lookup-grid sorties is STAGING ONLY. env=%', v_env;
+  END IF;
+
+  -- Volume ambiant : déjà calculé par trg_01_sorties_set_volume_ambiant ou fourni
+  v_volume_ambiant := NEW.volume_ambiant;
+  IF v_volume_ambiant IS NULL AND NEW.index_avant IS NOT NULL AND NEW.index_apres IS NOT NULL THEN
+    v_volume_ambiant := NEW.index_apres - NEW.index_avant;
+    NEW.volume_ambiant := v_volume_ambiant;
+  END IF;
+  IF v_volume_ambiant IS NULL OR v_volume_ambiant <= 0 THEN
+    RAISE EXCEPTION 'VOLUME_AMBIANT_REQUIRED';
+  END IF;
+
+  v_temp := NEW.temperature_ambiante_c;
+  IF v_temp IS NULL THEN
+    RAISE EXCEPTION 'TEMPERATURE_REQUIRED';
+  END IF;
+
+  -- densite_a_15_kgm3 utilisé comme input legacy (densité observée au moment de la saisie)
+  v_density_obs := NEW.densite_a_15_kgm3;
+  IF v_density_obs IS NULL THEN
+    RAISE EXCEPTION 'DENSITE_OBSERVEE_REQUIRED';
+  END IF;
+
+  -- Appel lookup-grid (batch GASOIL_P0_2026-02-28)
+  SELECT * INTO r
+  FROM astm.compute_v15_from_lookup_grid(
+    v_volume_ambiant,
+    v_temp,
+    v_density_obs,
+    'GASOIL',
+    'ASTM_OFFICIAL_APP',
+    'API_MPMS_11_1',
+    'GASOIL_P0_2026-02-28'
+  );
+
+  -- Convention : litre entier (aligné réceptions et historique sorties)
+  NEW.volume_corrige_15c := round(r.volume_15c_l);
+  NEW.densite_a_15_kgm3 := r.densite_a_15_kgm3;
+  NEW.densite_a_15_g_cm3 := r.densite_a_15_kgm3 / 1000.0;
+
+  RETURN NEW;
+END;
+$$;
+
+-- 3) Création du trigger dans le bon ordre (après trg_01_sorties_set_volume_ambiant)
+DROP TRIGGER IF EXISTS trg_02_sorties_compute_lookup_15c ON public.sorties_produit;
+CREATE TRIGGER trg_02_sorties_compute_lookup_15c
+  BEFORE INSERT ON public.sorties_produit
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sorties_compute_15c_before_ins_lookup();
+```
+
+**Ordre final des triggers** (BEFORE INSERT sur `sorties_produit`) :
+
+1. `trg_00_sorties_set_created_by`
+2. `trg_01_sorties_set_volume_ambiant`
+3. `trg_02_sorties_compute_lookup_15c`
+4. `trg_sorties_check_produit_citerne`
+5. `trg_sortie_before_ins`
+6. (AFTER INSERT : `trg_sorties_after_insert`)
+
+---
+
+## 7. Vérifications
+
+- **Triggers** : Vérifier la présence de `trg_02_sorties_compute_lookup_15c` et l’absence de `trg_00_sorties_compute_golden_15c` sur `public.sorties_produit`.
+- **Smoke test nominal** : validé (1000 L → 997 L) — insérer une sortie de test (volume 1000 L, température 19 °C, densité observée 837) ; contrôler `volume_corrige_15c = 997` et densité à 15°C ≈ 839,7.
+- **Smoke test hors domaine** : validé (densité = 900 → erreur `ASTM_BILINEAR_OUT_OF_DOMAIN_DENS`) — le moteur rejette les entrées hors grille avec un message explicite.
+- **Snapshot** : Avant/après validation de la sortie, vérifier que le snapshot (stocks_snapshot / v_stock_actuel) décrémente de −1000 (ambiant) et −997 (15°C).
+- **Logs** : Vérifier la présence d’une entrée `SORTIE_VALIDE` (ou équivalent) dans `log_actions` avec les détails de la sortie.
+
+---
+
+## 8. Résultat
+
+- **Sortie de test validée** : `sortie_id = 0eaa2cc8-5ccc-484d-9358-5176f698ec7e`.
+- **Entrée** : volume 1000 L, température 19 °C, densité 837.
+- **Résultat** : `volume_corrige_15c = 997`, densité à 15°C = 839,7.
+- **Pipeline aval** : Snapshot et logs cohérents ; débit −1000 / −997 confirmé.
+
+---
+
+## 9. Risques
+
+- **`densite_a_15_kgm3` utilisé comme input legacy** : En entrée, ce champ transporte encore la **densité observée** (terrain) au moment de la saisie. Le trigger le lit comme entrée, calcule la vraie densité à 15°C via le lookup-grid, puis **réécrit** `densite_a_15_kgm3` (et `densite_a_15_g_cm3`) avec la valeur calculée. Toute logique ou interface qui lit `densite_a_15_kgm3` **après** INSERT voit donc la densité à 15°C calculée, pas l’observée. Documenter cette convention pour éviter toute confusion.
+
+---
+
+## Centralized domain guard enhancement
+
+Après l’homogénéisation sorties → lookup-grid, une amélioration de robustesse a été ajoutée en STAGING : **garde-fou centralisé du domaine** du batch lookup-grid et **assertion centralisée** avant calcul.
+
+### Objectif
+
+- **Lecture centralisée du domaine** du batch lookup-grid : une seule source de vérité pour les bornes (densité, température) et le nombre de lignes.
+- **Assertion centralisée avant calcul** : les triggers réceptions et sorties appellent une même fonction d’assertion avant d’invoquer le moteur de calcul, ce qui évite d’appeler le moteur avec des valeurs hors domaine et standardise les messages d’erreur.
+
+### SQL concerné
+
+Le script STAGING (post-migration sorties lookup-grid) a ajouté :
+
+- **`astm.lookup_grid_domain(p_produit_code, p_source, p_method_version, p_batch_id)`** : retourne `dens_min`, `dens_max`, `temp_min`, `temp_max`, `rows_count` pour le batch actif.
+- **`astm.assert_lookup_grid_domain(p_produit_code, p_source, p_method_version, p_batch_id, p_temperature_c, p_densite_observee_kgm3)`** : vérifie que (température, densité observée) est dans le domaine ; lève une erreur claire si hors domaine.
+
+Puis mise à jour des fonctions de trigger pour appeler l’assertion avant le calcul :
+
+- **`public.receptions_compute_15c_before_ins()`** : appel à `astm.assert_lookup_grid_domain(...)` avant `astm.compute_v15_from_lookup_grid(...)`.
+- **`public.sorties_compute_15c_before_ins_lookup()`** : idem.
+
+### Vérifications réalisées
+
+- **`select * from astm.lookup_grid_domain(...)`** (avec les paramètres du batch GASOIL actif) : résultat **820 / 860 / 10 / 40 / 63** (dens_min, dens_max, temp_min, temp_max, rows_count).
+- **Test hors domaine** : entrée avec densité = **900**, température = 19, batch GASOIL lookup-grid. Erreur attendue et obtenue : **`ASTM_LOOKUP_OUT_OF_DOMAIN_DENS`** avec message explicite (produit=GASOIL, source=ASTM_OFFICIAL_APP, method=API_MPMS_11_1, batch=GASOIL_P0_2026-02-28, dens=900 outside [820,860]).
+
+### Impact
+
+- **Ne change pas** le moteur mathématique (interpolation, VCF, volume à 15°C).
+- **Ne change pas** la convention d’arrondi (litre entier).
+- **Ne change pas** le pipeline stock / logs.
+- **Améliore** uniquement la robustesse (validation explicite avant calcul) et la qualité des erreurs (message standardisé hors domaine).
+
+### Limite
+
+- Amélioration **STAGING uniquement**.
+- **Non déployée en PROD** : les fonctions et le branchement des triggers n’existent pas en PROD.
+- **Aucune migration PROD exécutée.**
+
+---
+
+## 10. Suite
+
+- **STAGING** : Homogène (réceptions + sorties = lookup-grid). Golden engine réservé à la validation.
+- **PROD** : Aucune migration PROD exécutée. La préparation de la migration PROD passe par : documentation complète, checklist ASTM, runbook migration PROD (`docs/RUNBOOKS/RUNBOOK_PROD_VOLUMETRIC_MIGRATION.md`), préparation du schéma et des colonnes PROD, backup et fenêtre d’intervention validés.
+
+---
+
+**Document créé** : 2026-03-07  
+**Référence** : Runbook — STAGING Sorties Lookup Grid Migration.


### PR DESCRIPTION
## Context

This PR documents the volumetric investigation and staging alignment performed on **2026-03-07** for the ASTM lookup-grid engine used in ML_PP MVP.

The investigation confirmed the correct behaviour of the **lookup-grid volumetric engine** and introduced a **centralized domain guard** to ensure that all volumetric computations remain inside the valid ASTM dataset domain.

This change is **documentation-only** and does **not modify production behaviour**.

---

## Key outcomes of the investigation

Staging lookup grid domain confirmed:

- Density range: **820 → 860 kg/m³**
- Temperature range: **10 → 40 °C**
- Grid size: **63 rows**

Validation tests executed:

- nominal volumetric calculations
- out-of-domain rejection
- trigger behaviour for receptions
- trigger behaviour for sorties

---

## Architectural change documented

Introduction of a **centralized domain guard**:

Functions:

- `astm.lookup_grid_domain()`
- `astm.assert_lookup_grid_domain()`

Purpose:

- guarantee volumetric inputs remain inside lookup-grid domain
- prevent invalid density / temperature inputs
- ensure deterministic volumetric calculations

The guard is now documented as being used by:

- reception volumetric triggers
- sortie volumetric triggers

---

## Files added
docs/POST_PROD/ASTM/2026-03-07_INVESTIGATION_STAGING_PROD_VOLUMETRIC_ALIGNMENT.md
docs/POST_PROD/ASTM/RUNBOOK_STAGING_SORTIES_LOOKUP_GRID_MIGRATION.md


---

## Safety

- No schema migration executed on PROD
- No volumetric engine change deployed
- Documentation only

---

## Next step

Prepare controlled **PROD migration runbook** once staging validation is complete.