### PR TITLE
docs(runbook): add final SQL purge sequence for ASTM PROD migration

### DIFF
--- a/docs/RUNBOOKS/RUNBOOK_PROD_VOLUMETRIC_MIGRATION.md
+++ b/docs/RUNBOOKS/RUNBOOK_PROD_VOLUMETRIC_MIGRATION.md
@@ -84,6 +84,100 @@ Après purge contrôlée CDR-aware :
 
 Ces 8 CDR pourront être **réceptionnés à nouveau** avec le moteur ASTM lookup-grid après migration.
 
+### Final SQL purge sequence (CDR-aware reset)
+
+La purge est **CDR-aware** : les réceptions sont supprimées avec leurs effets dérivés (logs, stocks_journaliers RECEPTION, stocks_snapshot), puis les CDR concernés sont rouverts au statut **ARRIVE**. Le stock journalier de type **SYSTEM** (ligne de base) est **préservé** ; seuls les enregistrements dérivés des réceptions sont supprimés.
+
+```sql
+begin;
+
+set local lock_timeout = '10s';
+set local statement_timeout = '5min';
+
+create temporary table tmp_receptions_to_purge as
+select
+  id as reception_id,
+  cours_de_route_id
+from public.receptions;
+
+select count(*) as receptions_to_purge
+from tmp_receptions_to_purge;
+
+delete from public.log_actions
+where module = 'receptions'
+  and details->>'reception_id' in (
+    select reception_id::text
+    from tmp_receptions_to_purge
+  );
+
+delete from public.stocks_snapshot
+where citerne_id in (
+  '2ed755b4-0306-4c7d-a6cd-1cc7de618625',
+  '91d2078b-8e19-43c2-bf33-322a42cd4e94'
+)
+and proprietaire_type = 'MONALUXE'
+and produit_id = '22222222-2222-2222-2222-222222222222';
+
+delete from public.stocks_journaliers
+where source = 'RECEPTION'
+  and proprietaire_type = 'MONALUXE'
+  and produit_id = '22222222-2222-2222-2222-222222222222'
+  and citerne_id in (
+    '2ed755b4-0306-4c7d-a6cd-1cc7de618625',
+    '91d2078b-8e19-43c2-bf33-322a42cd4e94'
+  );
+
+delete from public.receptions
+where id in (
+  select reception_id
+  from tmp_receptions_to_purge
+);
+
+update public.cours_de_route
+set statut = 'ARRIVE'
+where id in (
+  select cours_de_route_id
+  from tmp_receptions_to_purge
+);
+
+select count(*) as receptions_after
+from public.receptions;
+
+select count(*) as sorties_after
+from public.sorties_produit;
+
+select count(*) as sj_reception_after
+from public.stocks_journaliers
+where source = 'RECEPTION';
+
+select count(*) as snapshots_after
+from public.stocks_snapshot
+where citerne_id in (
+  '2ed755b4-0306-4c7d-a6cd-1cc7de618625',
+  '91d2078b-8e19-43c2-bf33-322a42cd4e94'
+)
+and proprietaire_type = 'MONALUXE'
+and produit_id = '22222222-2222-2222-2222-222222222222';
+
+select id, statut
+from public.cours_de_route
+where id in (
+  select cours_de_route_id
+  from tmp_receptions_to_purge
+)
+order by id;
+
+commit;
+```
+
+**Résultats attendus après purge**
+
+- `receptions` = 0  
+- `sorties_produit` = 0  
+- `stocks_journaliers` : conservation uniquement de la ligne de base SYSTEM  
+- `stocks_snapshot` : vide (0 ligne pour les citernes/produit concernés)  
+- Les 8 CDR repassés au statut **ARRIVE**
+
 ---
 
 ## 3. Références techniques


### PR DESCRIPTION
…D migration

- document final validated SQL sequence for controlled purge of 8 MONALUXE receptions
- include CDR-aware reset strategy (reopen CDR to ARRIVE after purge)
- document deletion of derived stocks_journaliers and stocks_snapshot
- document purge of log_actions via details->>'reception_id'
- preserve SYSTEM baseline stocks_journaliers
- add post-purge validation checklist
- documentation only, no code or SQL engine change