### PR TITLE
fix(web): force service worker update to prevent Safari white screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 
 ---
 
+## Fix — Safari white screen (Flutter Web)
+
+**Date :** 2026-03-13
+
+Correction d'un problème d'écran blanc sur Safari après déploiement Flutter Web.
+
+**Cause :** Safari utilisait un ancien service worker Flutter (`flutter_service_worker.js`) chargé depuis le cache.
+
+**Résolution :** Ajout d'un script dans `web/index.html` pour forcer la mise à jour du service worker lors du chargement de l'application :
+
+```javascript
+window.addEventListener('load', function () {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then(function (registrations) {
+      for (const registration of registrations) {
+        registration.update();
+      }
+    });
+  }
+});
+```
+
+Redéploiement de l'application via :
+
+- `flutter build web --release`
+- `firebase deploy --only hosting`
+
+**Impact :**
+
+- Safari compatible
+- Chrome inchangé
+- Aucun impact backend
+
+---
+
 ## Volumetric Engine Migration — PROD aligned with STAGING runtime
 
 ### Added

--- a/web/index.html
+++ b/web/index.html
@@ -34,5 +34,18 @@
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>
+
+  <script>
+    window.addEventListener('load', function () {
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations().then(function (registrations) {
+          for (const registration of registrations) {
+            registration.update();
+          }
+        });
+      }
+    });
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
Fix Safari white screen caused by stale Flutter service worker cache.

Changes:
- Added service worker update script in web/index.html
- Documented fix in CHANGELOG

Impact:
- Safari loads latest Flutter build after deployment
- Prevents blank screen due to cached flutter_service_worker.js

Tested:
- Chrome OK
- Safari OK after cache refresh