### PR TITLE
feat: volume_15c compat migration (staging + prod + flutter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ Ce fichier documente les changements notables du projet **ML_PP MVP**, conformé
 
 ---
 
+## Migration `volume_15c` — compatibilité sorties (STAGING, PROD, Flutter)
+
+Migration **validée** en mode **compatibilité** : introduction de la colonne canonique **`volume_15c`** sur **`sorties_produit`**, **sans** suppression de **`volume_corrige_15c`** et **sans** backfill historique destructif sur les sorties.
+
+### Base de données (STAGING puis PROD)
+
+- Ajout de **`public.sorties_produit.volume_15c`**.
+- Adaptation de **`sorties_compute_15c_before_ins_lookup()`** pour écrire **`volume_15c`** et conserver **`volume_corrige_15c`**.
+- Adaptation cohérente de **`sorties_after_insert_trg()`**, **`sorties_before_validate_trg()`**, **`validate_sortie(uuid)`**, **`create_sortie(...)`** (liste factuelle telle que déployée).
+- Usage interne aligné sur **`coalesce(volume_15c, volume_corrige_15c)`** où applicable ; **pas** de retrait du legacy dans cette phase.
+
+### Validation STAGING
+
+- Sortie test : **`volume_corrige_15c`** et **`volume_15c`** cohérents (ex. 10 / 10) ; stock, **`stocks_snapshot`**, **`stocks_journaliers`**, **`log_actions`** validés.
+
+### Validation PROD
+
+- Même schéma fonctionnel déployé ; smoke test sortie avec colonnes **`volume_corrige_15c`** et **`volume_15c`** renseignées ; snapshot décrémenté correctement.
+- Test PROD **compensé** (ajustement stock + correction snapshot technique **`stock_snapshot_apply_delta`** si nécessaire) pour ne pas laisser d’état parasite sur la base réelle.
+
+### Flutter (lecture uniquement)
+
+- Priorité de lecture **`volume_15c ?? volume_corrige_15c`** sur : KPI centraux, repositories réceptions/sorties, providers sorties, écrans d’ajustements de stock.
+- **Aucun** changement des payloads d’écriture dans ce cadre ; modèles / services **non** entièrement harmonisés sur une seule clé — dette documentée.
+
+### Documentation
+
+- `docs/00_REFERENCE/VOLUME_15C_MIGRATION_SUMMARY.md` — résumé technique.
+- `docs/RUNBOOKS/RUNBOOK_VOLUME_15C_COMPAT_MIGRATION.md` — mini runbook / rollback logique.
+- `docs/00_REFERENCE/VOLUME_15C_COMPATIBILITY_NOTE.md` — note de compatibilité lecture.
+
+### Architecture rappelée
+
+- **`v_stock_actuel`** : source de vérité métier stock actuel.
+- **`stocks_snapshot`** : cache / structure dérivée ; peut nécessiter une action explicite après incident.
+
+---
+
 ## Fix — Safari white screen (Flutter Web)
 
 **Date :** 2026-03-13

--- a/docs/00_REFERENCE/VOLUME_15C_COMPATIBILITY_NOTE.md
+++ b/docs/00_REFERENCE/VOLUME_15C_COMPATIBILITY_NOTE.md
@@ -1,0 +1,56 @@
+# Note de compatibilité — `volume_15c` et `volume_corrige_15c`
+
+**Projet** : ML_PP MVP  
+**Objet** : règles de lecture et coexistence des colonnes volume à 15 °C.  
+**Public** : développeurs Flutter, intégrateurs, audit technique.
+
+---
+
+## 1. Pourquoi deux colonnes coexistent
+
+- **`volume_corrige_15c`** : nom et contrat **historiques** (legacy), encore présents en base et dans une partie du code (modèles JSON, certains champs Dart).  
+- **`volume_15c`** : colonne **cible** introduite pour aligner le schéma sur la sémantique « volume à 15 °C » explicite, en particulier sur **`sorties_produit`** après migration STAGING puis PROD.
+
+La migration validée est en mode **compatibilité** : les deux colonnes sont **remplies** sur le chemin runtime sorties (selon la version déployée des triggers), **sans** suppression de l’ancienne.
+
+---
+
+## 2. Colonne cible vs legacy
+
+| Rôle | Colonne | Remarque |
+|------|---------|----------|
+| **Cible canonique (volume @15 °C)** | **`volume_15c`** | À privilégier pour toute **nouvelle** lecture applicative. |
+| **Legacy / compatibilité** | **`volume_corrige_15c`** | À conserver tant que les données anciennes ou le code ne sont pas entièrement migrés. |
+
+---
+
+## 3. Règle de lecture recommandée (Flutter / agrégations)
+
+Pour interpréter le volume corrigé à 15 °C à partir d’une ligne `Map` ou équivalent Supabase :
+
+```text
+valeur_15c_effective = volume_15c ?? volume_corrige_15c
+```
+
+(en Dart typiquement : cast `num?` puis `?.toDouble()`, avec `??` entre les deux clés, puis défaut métier si besoin, **sans** utiliser `volume_ambiant` comme substitut du volume @15 °C sauf règle métier explicite documentée ailleurs).
+
+Cette règle a été appliquée sur les périmètres **lecture** migrés (KPI, repositories, providers sorties, écrans d’ajustements de stock), **sans** modification des payloads d’écriture dans le cadre de cette phase.
+
+---
+
+## 4. Ce qui n’a pas encore été fait (hors périmètre actuel)
+
+- **Suppression** de `volume_corrige_15c` : **non**.  
+- **Backfill historique** destructif ou `UPDATE` massif sur `sorties_produit` : **non** revendiqué ; la table reste soumise à la gouvernance d’immutabilité en conditions normales.  
+- **Harmonisation complète** des modèles Dart / Freezed sur un seul nom de propriété miroir de `volume_15c` : **non**.  
+- **Refactor** des services d’écriture pour n’exposer qu’une seule clé JSON : **non** dans cette migration de compatibilité.
+
+Toute évolution ultérieure doit faire l’objet d’un **ADR**, de scripts versionnés et d’un runbook dédié.
+
+---
+
+## 5. Références
+
+- Synthèse migration : `docs/00_REFERENCE/VOLUME_15C_MIGRATION_SUMMARY.md`  
+- Runbook : `docs/RUNBOOKS/RUNBOOK_VOLUME_15C_COMPAT_MIGRATION.md`  
+- CHANGELOG : entrée `[Unreleased]` — migration `volume_15c` (compatibilité)

--- a/docs/00_REFERENCE/VOLUME_15C_MIGRATION_SUMMARY.md
+++ b/docs/00_REFERENCE/VOLUME_15C_MIGRATION_SUMMARY.md
@@ -1,0 +1,96 @@
+# Résumé technique — migration `volume_15c` (mode compatibilité)
+
+**Projet** : ML_PP MVP  
+**Statut** : migration validée (STAGING puis PROD), sans suppression du legacy.  
+**Document** : synthèse factuelle pour audit et onboarding technique.
+
+---
+
+## Contexte
+
+Le moteur volumétrique et les triggers écrivent désormais le volume corrigé à 15 °C dans une colonne explicite **`volume_15c`**. La colonne historique **`volume_corrige_15c`** reste en place pour compatibilité transitoire. L’application Flutter a été alignée en **lecture** sur la règle `volume_15c` en priorité, `volume_corrige_15c` en secours, **sans** refonte complète des modèles ni des payloads d’écriture.
+
+---
+
+## Problème initial
+
+- **Réceptions** : déjà partiellement orientées vers `volume_15c`.
+- **Sorties** : runtime et stock dérivés encore fortement couplés à `volume_corrige_15c`.
+- **Flutter** : lectures majoritairement legacy-first ; besoin d’homogénéiser la lecture sans casser l’existant ni les écritures.
+
+---
+
+## Solution appliquée (vue d’ensemble)
+
+1. **Base de données (STAGING puis PROD)**  
+   - Ajout de **`public.sorties_produit.volume_15c`**.  
+   - Adaptation des fonctions et triggers concernés pour **écrire** `volume_15c` **et conserver** `volume_corrige_15c` (compatibilité).  
+   - Usage logique côté métier / triggers dérivés : **`coalesce(volume_15c, volume_corrige_15c)`** où applicable.  
+   - **Pas** de suppression de colonnes legacy.  
+   - **Pas** de backfill destructif sur `sorties_produit` (table à écriture contrôlée / immuable en conditions normales).
+
+2. **Flutter (lecture uniquement)**  
+   - Priorité de lecture : **`volume_15c ?? volume_corrige_15c`** sur les périmètres ciblés (KPI, repositories réceptions/sorties, providers sorties, écrans d’ajustements de stock).  
+   - **Aucun** changement des payloads d’insert/update métier dans le cadre de cette migration de compatibilité.
+
+---
+
+## Validation STAGING
+
+- Sortie test créée en STAGING : **`volume_corrige_15c = 10`**, **`volume_15c = 10`**.  
+- Décrément de stock cohérent ; **`stocks_snapshot`**, **`stocks_journaliers`** et **`log_actions`** alignés avec l’attendu.  
+- **Conclusion** : STAGING validé en mode compatibilité.
+
+---
+
+## Validation PROD
+
+- Même schéma d’évolution DB que STAGING (colonne `volume_15c` + adaptations triggers / fonctions listées dans le runbook).  
+- Smoke test PROD : sortie test avec **`volume_corrige_15c = 10`**, **`volume_15c = 10`** ; snapshot de stock décrémenté correctement ; **migration runtime validée**.
+
+---
+
+## Correction du test PROD
+
+La base PROD étant en usage réel (Monaluxe), le mouvement de test a été **compensé** :
+
+- Ajustement de stock via **`stocks_adjustments`** sur la sortie test.  
+- Constat : **`v_stock_actuel`** revenu cohérent, **`stocks_snapshot`** encore désynchronisé.  
+- Correction technique du snapshot via **`stock_snapshot_apply_delta(...)`** (procédure dédiée).  
+- **État final** : restauré ; stock métier non laissé pollué.
+
+---
+
+## Décisions d’architecture retenues
+
+| Élément | Rôle |
+|--------|------|
+| **`v_stock_actuel`** | Source de vérité **métier** pour le stock actuel. |
+| **`stocks_snapshot`** | Cache / structure technique **dérivée** ; peut nécessiter une resynchronisation explicite après opérations exceptionnelles. |
+| **`volume_15c`** | Colonne **cible canonique** pour le volume à 15 °C sur les nouveaux chemins. |
+| **`volume_corrige_15c`** | Colonne **legacy**, **conservée** ; compatibilité transitoire. |
+
+---
+
+## État final (après migration)
+
+- STAGING et PROD disposent de **`sorties_produit.volume_15c`** alimentée par le runtime aligné avec la stratégie de compatibilité.  
+- Flutter lit en priorité **`volume_15c`** avec repli sur **`volume_corrige_15c`** sur les zones migrées.  
+- **Aucune** suppression du legacy dans cette phase.  
+- **Aucun** backfill historique global sur les sorties n’est revendiqué dans ce document.
+
+---
+
+## Dette restante (hors périmètre de cette migration)
+
+- Modèles Dart / Freezed : **non** entièrement harmonisés sur un seul nom de champ JSON.  
+- Services d’écriture : **non** refactorés pour n’envoyer qu’une seule sémantique côté API.  
+- Convergence finale (retrait progressif de `volume_corrige_15c`) : **non** réalisée ; à traiter dans un chantier ultérieur explicite, avec ADR et migration de schéma si applicable.
+
+---
+
+## Références
+
+- Runbook opérationnel : `docs/RUNBOOKS/RUNBOOK_VOLUME_15C_COMPAT_MIGRATION.md`  
+- Note de compatibilité lecture : `docs/00_REFERENCE/VOLUME_15C_COMPATIBILITY_NOTE.md`  
+- CHANGELOG : section `[Unreleased]` — migration `volume_15c` (compatibilité)

--- a/docs/RUNBOOKS/RUNBOOK_VOLUME_15C_COMPAT_MIGRATION.md
+++ b/docs/RUNBOOKS/RUNBOOK_VOLUME_15C_COMPAT_MIGRATION.md
@@ -1,0 +1,114 @@
+# Runbook — migration `volume_15c` (compatibilité sorties)
+
+**Document** : procédure de référence pour la migration colonne `volume_15c` sur `sorties_produit`, en mode **compatibilité** (conservation de `volume_corrige_15c`).  
+**Projet** : ML_PP MVP  
+**Public** : développeurs, DBA, release.
+
+**Résumé détaillé** : `docs/00_REFERENCE/VOLUME_15C_MIGRATION_SUMMARY.md`  
+**Lecture applicative** : `docs/00_REFERENCE/VOLUME_15C_COMPATIBILITY_NOTE.md`
+
+---
+
+## 1. But
+
+- Introduire **`public.sorties_produit.volume_15c`** comme colonne canonique pour le volume à 15 °C sur le chemin runtime.  
+- Continuer à remplir **`volume_corrige_15c`** pour compatibilité transitoire.  
+- Adapter triggers et fonctions critiques sans backfill destructif sur les lignes historiques immuables.  
+- Valider par smoke test, puis annuler proprement tout test sur PROD réelle.
+
+---
+
+## 2. Prérequis
+
+- Backup base (STAGING puis PROD) avant toute migration DDL / fonction.  
+- Scripts SQL révisés et exécutés d’abord sur **STAGING**.  
+- Fenêtre de validation STAGING complète avant reproduction PROD.  
+- Accès aux fonctions de maintenance snapshot si correction post-test nécessaire (ex. `stock_snapshot_apply_delta`).
+
+---
+
+## 3. Étapes STAGING (référence)
+
+Ordre logique documenté (détail SQL dans les scripts du dépôt / tickets associés) :
+
+1. Ajouter la colonne **`public.sorties_produit.volume_15c`** (type aligné sur le projet).  
+2. Adapter **`sorties_compute_15c_before_ins_lookup()`** pour écrire **`volume_15c`** et **`volume_corrige_15c`**.  
+3. Adapter les dépendances cohérentes avec le stock et la validation, notamment :  
+   - **`sorties_after_insert_trg()`**  
+   - **`sorties_before_validate_trg()`**  
+   - **`validate_sortie(uuid)`**  
+   - **`create_sortie(...)`**  
+4. Vérifier que la logique métier utilise **`coalesce(volume_15c, volume_corrige_15c)`** là où le volume @15 °C est consommé en interne.  
+5. **Ne pas** supprimer `volume_corrige_15c`.  
+6. **Ne pas** lancer de backfill massif `UPDATE` sur `sorties_produit` en contournant la gouvernance d’immutabilité.
+
+---
+
+## 4. Validation STAGING
+
+- Créer une **sortie test** (volume connu).  
+- Vérifier sur la ligne : **`volume_corrige_15c`** et **`volume_15c`** renseignés de façon cohérente (ex. même valeur pour le cas test validé).  
+- Contrôler décrément **stock** (journaliers / logique métier).  
+- Contrôler **`stocks_snapshot`**, **`stocks_journaliers`**, **`log_actions`**.  
+- **Gate** : aucune régression sur création sortie « normale » et sur la lecture **`v_stock_actuel`**.
+
+---
+
+## 5. Étapes PROD
+
+- Reproduire **strictement** le même jeu de changements que STAGING (DDL + fonctions + triggers).  
+- Vérifier déploiement sur le bon projet Supabase / instance.  
+- Ne pas exécuter de script destructif hors runbook validé.
+
+---
+
+## 6. Smoke test PROD
+
+- Créer une **sortie test** en PROD (données et volume documentés).  
+- Vérifier **`volume_corrige_15c`** et **`volume_15c`** sur la ligne créée.  
+- Vérifier décrément **`stocks_snapshot`** (ou indicateur équivalent validé par l’équipe).  
+- **Important** : PROD étant en usage réel, prévoir **immédiatement** la section 7.
+
+---
+
+## 7. Annulation propre d’un test PROD
+
+Si une sortie test a été créée sur PROD exploité :
+
+1. Enregistrer un **`stocks_adjustments`** (ou mécanisme approuvé) lié au mouvement test pour compenser l’impact métier.  
+2. Vérifier **`v_stock_actuel`** (source de vérité métier).  
+3. Si **`stocks_snapshot`** reste désynchronisé par rapport à l’état attendu : appliquer la correction technique documentée (ex. **`stock_snapshot_apply_delta(...)`**) sous contrôle et traçabilité.  
+4. Vérifier l’**état final** : pas de pollution durable du stock réel opérateur.
+
+---
+
+## 8. Vérifications post-migration
+
+- Nouvelle sortie « réelle » ou de non-régression : **`volume_15c`** et **`volume_corrige_15c`** présents selon le contrat runtime.  
+- **`v_stock_actuel`** cohérent après enchaînement réception / sortie.  
+- Application Flutter : écrans KPI / listes / ajustements affichent des volumes @15 °C cohérents (lecture prioritaire `volume_15c`).  
+- Logs / triggers : pas d’erreur récurrente sur insert sortie.
+
+---
+
+## 9. Rollback logique (non destructif)
+
+Ce runbook **ne prescrit pas** un rollback par `DELETE` massif sur `sorties_produit`.
+
+En cas de régression critique après déploiement :
+
+1. **Geler** les nouvelles sorties si la politique métier l’exige.  
+2. **Restaurer** la base depuis le **backup** pré-migration (fenêtre d’intervention validée).  
+3. Ou : redéployer la **version précédente** des fonctions/triggers **uniquement** si une procédure de rollback SQL validée existe (hors scope de ce document si non versionnée).  
+4. **Journaliser** la décision (ticket, date, auteur).
+
+Toute restauration complète implique perte des données post-backup : à planifier avec le métier.
+
+---
+
+## 10. Rappels gouvernance
+
+- **`v_stock_actuel`** : vérité métier stock actuel.  
+- **`stocks_snapshot`** : dérivé technique ; peut nécessiter une action explicite après incident.  
+- **`volume_15c`** : cible canonique volume @15 °C (chemin nouveau).  
+- **`volume_corrige_15c`** : legacy conservé ; pas de suppression dans cette migration.

--- a/lib/data/repositories/receptions_repository.dart
+++ b/lib/data/repositories/receptions_repository.dart
@@ -24,7 +24,7 @@ class ReceptionsRepository {
         rows = await _supa
             .from('receptions')
             .select(
-              'id, statut, volume_corrige_15c, volume_ambiant, citernes!inner(depot_id)',
+              'id, statut, volume_15c, volume_corrige_15c, volume_ambiant, citernes!inner(depot_id)',
             )
             .eq('statut', 'validee')
             .eq('date_reception', eqDay)
@@ -33,7 +33,7 @@ class ReceptionsRepository {
         // Global
         rows = await _supa
             .from('receptions')
-            .select('id, statut, volume_corrige_15c, volume_ambiant')
+            .select('id, statut, volume_15c, volume_corrige_15c, volume_ambiant')
             .eq('statut', 'validee')
             .eq('date_reception', eqDay);
       }
@@ -45,7 +45,9 @@ class ReceptionsRepository {
         count++;
         // Ambiant : privilégier la colonne volume_ambiant si présente, sinon 0
         final amb = (m['volume_ambiant'] as num?)?.toDouble() ?? 0.0;
-        final v15 = (m['volume_corrige_15c'] as num?)?.toDouble() ?? 0.0;
+        final v15 = (m['volume_15c'] as num?)?.toDouble() ??
+            (m['volume_corrige_15c'] as num?)?.toDouble() ??
+            0.0;
         sAmb += amb;
         s15 += v15;
       }

--- a/lib/data/repositories/sorties_repository.dart
+++ b/lib/data/repositories/sorties_repository.dart
@@ -25,7 +25,7 @@ class SortiesRepository {
   }) async {
     // colonnes communes
     String baseCols =
-        'id, statut, volume_ambiant, volume_corrige_15c, date_sortie';
+        'id, statut, volume_ambiant, volume_15c, volume_corrige_15c, date_sortie';
     var query = _supa.from('sorties_produit').select(baseCols);
 
     // join citernes si filtre dépôt
@@ -46,7 +46,9 @@ class SortiesRepository {
     for (final m in (rows as List)) {
       count++;
       sAmb += (m['volume_ambiant'] as num?)?.toDouble() ?? 0.0;
-      s15 += (m['volume_corrige_15c'] as num?)?.toDouble() ?? 0.0;
+      s15 += (m['volume_15c'] as num?)?.toDouble() ??
+          (m['volume_corrige_15c'] as num?)?.toDouble() ??
+          0.0;
     }
 
     if (kDebugMode) {

--- a/lib/features/dashboard/providers/directeur_kpi_provider.dart
+++ b/lib/features/dashboard/providers/directeur_kpi_provider.dart
@@ -44,28 +44,30 @@ final directeurKpiProvider = FutureProvider<DirecteurKpiData>((ref) async {
   // Réceptions du jour (DATE)
   final recs = await supa
       .from('receptions')
-      .select('id, volume_corrige_15c, volume_ambiant')
+      .select('id, volume_15c, volume_corrige_15c, volume_ambiant')
       .eq('statut', 'validee')
       .eq('date_reception', _ymd(dayStart));
 
   // Sorties du jour (TIMESTAMPTZ)
   final sorties = await supa
       .from('sorties_produit')
-      .select('id, volume_corrige_15c, volume_ambiant')
+      .select('id, volume_15c, volume_corrige_15c, volume_ambiant')
       .eq('statut', 'validee')
       .gte('date_sortie', _isoUtc(dayStart))
       .lt('date_sortie', _isoUtc(dayEnd));
 
   double sumReceptions = 0.0;
   for (final m in (recs as List)) {
-    final v15 = (m['volume_corrige_15c'] as num?)?.toDouble();
+    final v15 = (m['volume_15c'] as num?)?.toDouble() ??
+        (m['volume_corrige_15c'] as num?)?.toDouble();
     final va = (m['volume_ambiant'] as num?)?.toDouble() ?? 0.0;
     sumReceptions += (v15 ?? va);
   }
 
   double sumSorties = 0.0;
   for (final m in (sorties as List)) {
-    final v15 = (m['volume_corrige_15c'] as num?)?.toDouble();
+    final v15 = (m['volume_15c'] as num?)?.toDouble() ??
+        (m['volume_corrige_15c'] as num?)?.toDouble();
     final va = (m['volume_ambiant'] as num?)?.toDouble() ?? 0.0;
     sumSorties += (v15 ?? va);
   }

--- a/lib/features/kpi/providers/kpi_provider.dart
+++ b/lib/features/kpi/providers/kpi_provider.dart
@@ -78,8 +78,9 @@ double _toD(dynamic v) {
 /// Elle peut être testée isolément avec des données mockées.
 ///
 /// RÈGLE MÉTIER :
-/// - Pas de fallback automatique : si volume_15c est null, il reste à 0
-/// - Les écarts entre volume_ambiant et volume_15c sont visibles dans le KPI
+/// - Volume @15°C : priorité `volume_15c`, sinon `volume_corrige_15c` (legacy) ; pas de fallback vers volume_ambiant
+/// - Si les deux colonnes sont absentes ou nulles après parsing, la contribution @15°C reste 0
+/// - Les écarts entre volume_ambiant et volume @15°C sont visibles dans le KPI
 /// - Compte séparément les réceptions MONALUXE vs PARTENAIRE
 KpiReceptions computeKpiReceptions(List<Map<String, dynamic>> rows) {
   var count = 0;
@@ -93,7 +94,7 @@ KpiReceptions computeKpiReceptions(List<Map<String, dynamic>> rows) {
 
     // Mapping strict des volumes - NE JAMAIS utiliser volume_ambiant comme fallback pour volume_15c
     final vAmb = _toD(row['volume_ambiant']);
-    final v15c = _toD(row['volume_corrige_15c'] ?? row['volume_15c']);
+    final v15c = _toD(row['volume_15c'] ?? row['volume_corrige_15c']);
 
     volumeAmbient += vAmb;
     volume15c += v15c;
@@ -123,8 +124,9 @@ KpiReceptions computeKpiReceptions(List<Map<String, dynamic>> rows) {
 /// Elle peut être testée isolément avec des données mockées.
 ///
 /// RÈGLE MÉTIER :
-/// - Pas de fallback automatique : si volume_15c est null, il reste à 0
-/// - Les écarts entre volume_ambiant et volume_15c sont visibles dans le KPI
+/// - Volume @15°C : priorité `volume_15c`, sinon `volume_corrige_15c` (legacy) ; pas de fallback vers volume_ambiant
+/// - Si les deux colonnes sont absentes ou nulles après parsing, la contribution @15°C reste 0
+/// - Les écarts entre volume_ambiant et volume @15°C sont visibles dans le KPI
 /// - Compte séparément les sorties MONALUXE vs PARTENAIRE
 KpiSorties computeKpiSorties(List<Map<String, dynamic>> rows) {
   var count = 0;
@@ -137,9 +139,9 @@ KpiSorties computeKpiSorties(List<Map<String, dynamic>> rows) {
     count++;
 
     // Mapping strict des volumes - NE JAMAIS utiliser volume_ambiant comme fallback pour volume_15c
-    // Priorité à volume_corrige_15c, sinon volume_15c, sinon 0
+    // Priorité à volume_15c, sinon volume_corrige_15c (legacy), sinon 0 via _toD
     final vAmb = _toD(row['volume_ambiant']);
-    final v15c = _toD(row['volume_corrige_15c'] ?? row['volume_15c']);
+    final v15c = _toD(row['volume_15c'] ?? row['volume_corrige_15c']);
 
     volumeAmbient += vAmb;
     volume15c += v15c;
@@ -175,7 +177,7 @@ typedef SortieRow = Map<String, dynamic>;
 /// sans dépendre de Supabase ou de RLS.
 ///
 /// Retourne les rows brutes avec les champs :
-/// - volume_corrige_15c (ou volume_15c)
+/// - volume_15c (priorité lecture) et volume_corrige_15c (fallback legacy)
 /// - volume_ambiant
 /// - proprietaire_type (optionnel)
 /// - id, date_reception, statut (pour debug)
@@ -195,7 +197,7 @@ Future<List<ReceptionRow>> _fetchReceptionsRawOfDay(
     result = await supa
         .from('receptions')
         .select(
-          'id, volume_corrige_15c, volume_ambiant, proprietaire_type, date_reception, statut, citernes!inner(depot_id)',
+          'id, volume_15c, volume_corrige_15c, volume_ambiant, proprietaire_type, date_reception, statut, citernes!inner(depot_id)',
         )
         .eq('statut', 'validee')
         .eq('date_reception', dayStr)
@@ -205,7 +207,7 @@ Future<List<ReceptionRow>> _fetchReceptionsRawOfDay(
     result = await supa
         .from('receptions')
         .select(
-          'id, volume_corrige_15c, volume_ambiant, proprietaire_type, date_reception, statut',
+          'id, volume_15c, volume_corrige_15c, volume_ambiant, proprietaire_type, date_reception, statut',
         )
         .eq('statut', 'validee')
         .eq('date_reception', dayStr);
@@ -216,7 +218,7 @@ Future<List<ReceptionRow>> _fetchReceptionsRawOfDay(
   double sum15c = 0.0;
   for (final row in result) {
     final vAmb = _toD(row['volume_ambiant']);
-    final v15c = _toD(row['volume_corrige_15c'] ?? row['volume_15c']);
+    final v15c = _toD(row['volume_15c'] ?? row['volume_corrige_15c']);
     sumAmb += vAmb;
     sum15c += v15c;
   }
@@ -253,7 +255,7 @@ final receptionsRawTodayProvider = FutureProvider.autoDispose<List<ReceptionRow>
 /// sans dépendre de Supabase ou de RLS.
 ///
 /// Retourne les rows brutes avec les champs :
-/// - volume_corrige_15c (ou volume_15c)
+/// - volume_15c (priorité lecture) et volume_corrige_15c (fallback legacy)
 /// - volume_ambiant
 /// - proprietaire_type (optionnel)
 /// - id, date_sortie, statut (pour debug)
@@ -274,7 +276,7 @@ Future<List<SortieRow>> _fetchSortiesRawOfDay(
     result = await supa
         .from('sorties_produit')
         .select(
-          'id, volume_corrige_15c, volume_ambiant, proprietaire_type, date_sortie, statut, citernes!inner(depot_id)',
+          'id, volume_15c, volume_corrige_15c, volume_ambiant, proprietaire_type, date_sortie, statut, citernes!inner(depot_id)',
         )
         .eq('statut', 'validee')
         .gte('date_sortie', dayStart)
@@ -285,7 +287,7 @@ Future<List<SortieRow>> _fetchSortiesRawOfDay(
     result = await supa
         .from('sorties_produit')
         .select(
-          'id, volume_corrige_15c, volume_ambiant, proprietaire_type, date_sortie, statut',
+          'id, volume_15c, volume_corrige_15c, volume_ambiant, proprietaire_type, date_sortie, statut',
         )
         .eq('statut', 'validee')
         .gte('date_sortie', dayStart)
@@ -297,7 +299,7 @@ Future<List<SortieRow>> _fetchSortiesRawOfDay(
   double sum15c = 0.0;
   for (final row in result) {
     final vAmb = _toD(row['volume_ambiant']);
-    final v15c = _toD(row['volume_corrige_15c'] ?? row['volume_15c']);
+    final v15c = _toD(row['volume_15c'] ?? row['volume_corrige_15c']);
     sumAmb += vAmb;
     sum15c += v15c;
   }

--- a/lib/features/receptions/kpi/receptions_kpi_repository.dart
+++ b/lib/features/receptions/kpi/receptions_kpi_repository.dart
@@ -20,7 +20,7 @@ class ReceptionsKpiRepository {
   ///
   /// Agrège :
   /// - count : nombre de réceptions
-  /// - volume15c : somme de volume_corrige_15c
+  /// - volume15c : somme de volume_15c avec fallback volume_corrige_15c (legacy)
   /// - volumeAmbient : somme de volume_ambiant
   ///
   /// Si cette structure est modifiée, mettre à jour:
@@ -55,7 +55,7 @@ class ReceptionsKpiRepository {
         // Global - récupérer toutes les réceptions validées du jour
         result = await client
             .from('receptions')
-            .select('volume_corrige_15c, volume_ambiant')
+            .select('volume_15c, volume_corrige_15c, volume_ambiant')
             .eq('date_reception', dateStr)
             .eq('statut', 'validee');
       }
@@ -72,8 +72,10 @@ class ReceptionsKpiRepository {
       for (final row in rows) {
         count += 1;
 
-        // Casting sécurisé avec gestion des nulls
-        final v15 = (row['volume_corrige_15c'] as num?)?.toDouble() ?? 0.0;
+        // Casting sécurisé : priorité volume_15c, fallback legacy volume_corrige_15c
+        final v15 = (row['volume_15c'] as num?)?.toDouble() ??
+            (row['volume_corrige_15c'] as num?)?.toDouble() ??
+            0.0;
         final vAmb = (row['volume_ambiant'] as num?)?.toDouble() ?? 0.0;
 
         volume15c += v15;

--- a/lib/features/sorties/kpi/sorties_kpi_repository.dart
+++ b/lib/features/sorties/kpi/sorties_kpi_repository.dart
@@ -20,7 +20,7 @@ class SortiesKpiRepository {
   ///
   /// Agrège :
   /// - count : nombre de sorties
-  /// - volume15c : somme de volume_corrige_15c
+  /// - volume15c : somme de volume_15c avec fallback volume_corrige_15c (legacy)
   /// - volumeAmbient : somme de volume_ambiant
   ///
   /// Si cette structure est modifiée, mettre à jour:
@@ -46,7 +46,7 @@ class SortiesKpiRepository {
         result = await client
             .from('sorties_produit')
             .select(
-              'volume_corrige_15c, volume_ambiant, citernes!inner(depot_id)',
+              'volume_15c, volume_corrige_15c, volume_ambiant, citernes!inner(depot_id)',
             )
             .eq('statut', 'validee')
             .gte('date_sortie', dayStartIso)
@@ -56,7 +56,7 @@ class SortiesKpiRepository {
         // Global - récupérer toutes les sorties validées du jour
         result = await client
             .from('sorties_produit')
-            .select('volume_corrige_15c, volume_ambiant')
+            .select('volume_15c, volume_corrige_15c, volume_ambiant')
             .eq('statut', 'validee')
             .gte('date_sortie', dayStartIso)
             .lt('date_sortie', dayEndIso);
@@ -75,8 +75,10 @@ class SortiesKpiRepository {
       for (final row in rows) {
         count += 1;
 
-        // Casting sécurisé avec gestion des nulls
-        final v15 = (row['volume_corrige_15c'] as num?)?.toDouble() ?? 0.0;
+        // Priorité volume_15c, fallback legacy volume_corrige_15c
+        final v15 = (row['volume_15c'] as num?)?.toDouble() ??
+            (row['volume_corrige_15c'] as num?)?.toDouble() ??
+            0.0;
         final vAmb = (row['volume_ambiant'] as num?)?.toDouble() ?? 0.0;
 
         volume15c += v15;

--- a/lib/features/sorties/providers/sortie_providers.dart
+++ b/lib/features/sorties/providers/sortie_providers.dart
@@ -52,7 +52,7 @@ final sortiesListProvider = Riverpod.FutureProvider<List<Map<String, dynamic>>>(
     final res = await client
         .from('sorties_produit')
         .select(
-          'id, created_at, date_sortie, proprietaire_type, volume_ambiant, volume_corrige_15c, '
+          'id, created_at, date_sortie, proprietaire_type, volume_ambiant, volume_15c, volume_corrige_15c, '
           'produits:produit_id(code, nom), citernes:citerne_id(nom), '
           'client:client_id(nom), partenaire:partenaire_id(nom)',
         )

--- a/lib/features/sorties/providers/sorties_table_provider.dart
+++ b/lib/features/sorties/providers/sorties_table_provider.dart
@@ -21,7 +21,7 @@ final sortiesTableProvider = FutureProvider.autoDispose<List<SortieRowVM>>((
   final sortiesRows = await supa
       .from('sorties_produit')
       .select(
-        'id, date_sortie, proprietaire_type, produit_id, citerne_id, volume_corrige_15c, volume_ambiant, statut, client_id, partenaire_id, created_at',
+        'id, date_sortie, proprietaire_type, produit_id, citerne_id, volume_15c, volume_corrige_15c, volume_ambiant, statut, client_id, partenaire_id, created_at',
       )
       .order('date_sortie', ascending: false);
 
@@ -101,7 +101,8 @@ final sortiesTableProvider = FutureProvider.autoDispose<List<SortieRowVM>>((
         propriete: proprietaireType,
         produitLabel: prodLabel.isEmpty ? '—' : prodLabel,
         citerneNom: cid != null ? (cNom[cid] ?? cid.substring(0, 8)) : '—',
-        vol15: (s['volume_corrige_15c'] as num?)?.toDouble(),
+        vol15: (s['volume_15c'] as num?)?.toDouble() ??
+            (s['volume_corrige_15c'] as num?)?.toDouble(),
         volAmb: (s['volume_ambiant'] as num?)?.toDouble(),
         beneficiaireNom: beneficiaireNom,
         statut: (s['statut'] as String? ?? 'brouillon'),

--- a/lib/features/stocks_adjustments/screens/stocks_adjustment_create_sheet.dart
+++ b/lib/features/stocks_adjustments/screens/stocks_adjustment_create_sheet.dart
@@ -88,7 +88,7 @@ class _StocksAdjustmentCreateSheetState
       final res = await client
           .from(tableName)
           .select(
-            'volume_ambiant, temperature_ambiante_c, densite_a_15, volume_corrige_15c',
+            'volume_ambiant, temperature_ambiante_c, densite_a_15, volume_15c, volume_corrige_15c',
           )
           .eq('id', widget.mouvementId)
           .maybeSingle();
@@ -102,6 +102,7 @@ class _StocksAdjustmentCreateSheetState
                 (data['temperature_ambiante_c'] as num?)?.toDouble(),
             densiteA15: (data['densite_a_15'] as num?)?.toDouble(),
             volumeCorrige15c:
+                (data['volume_15c'] as num?)?.toDouble() ??
                 (data['volume_corrige_15c'] as num?)?.toDouble(),
           );
           _isLoadingMovement = false;

--- a/lib/features/stocks_adjustments/screens/stocks_adjustments_list_screen.dart
+++ b/lib/features/stocks_adjustments/screens/stocks_adjustments_list_screen.dart
@@ -292,7 +292,7 @@ class StocksAdjustmentsListScreen extends ConsumerWidget {
       if (type == 'RECEPTION') {
         final res = await client
             .from('receptions')
-            .select('id, date_reception, volume_corrige_15c, produits:produit_id(nom)')
+            .select('id, date_reception, volume_15c, volume_corrige_15c, produits:produit_id(nom)')
             .order('date_reception', ascending: false)
             .limit(20);
 
@@ -301,7 +301,9 @@ class StocksAdjustmentsListScreen extends ConsumerWidget {
             final map = row as Map<String, dynamic>;
             final id = map['id'] as String? ?? '';
             final date = map['date_reception'] as String? ?? '';
-            final volume = (map['volume_corrige_15c'] as num?)?.toDouble() ?? 0.0;
+            final volume = (map['volume_15c'] as num?)?.toDouble() ??
+                (map['volume_corrige_15c'] as num?)?.toDouble() ??
+                0.0;
             final produit = map['produits'] as Map<String, dynamic>?;
             final produitNom = produit?['nom'] as String? ?? 'Produit inconnu';
 
@@ -315,7 +317,7 @@ class StocksAdjustmentsListScreen extends ConsumerWidget {
       } else if (type == 'SORTIE') {
         final res = await client
             .from('sorties_produit')
-            .select('id, date_sortie, volume_corrige_15c, produits:produit_id(nom)')
+            .select('id, date_sortie, volume_15c, volume_corrige_15c, produits:produit_id(nom)')
             .order('date_sortie', ascending: false)
             .limit(20);
 
@@ -328,7 +330,9 @@ class StocksAdjustmentsListScreen extends ConsumerWidget {
             final date = dateStr.isNotEmpty && dateStr.length >= 10
                 ? dateStr.substring(0, 10)
                 : 'Date inconnue';
-            final volume = (map['volume_corrige_15c'] as num?)?.toDouble() ?? 0.0;
+            final volume = (map['volume_15c'] as num?)?.toDouble() ??
+                (map['volume_corrige_15c'] as num?)?.toDouble() ??
+                0.0;
             final produit = map['produits'] as Map<String, dynamic>?;
             final produitNom = produit?['nom'] as String? ?? 'Produit inconnu';
 

--- a/test/features/kpi/kpi_receptions_compute_test.dart
+++ b/test/features/kpi/kpi_receptions_compute_test.dart
@@ -121,11 +121,12 @@ void main() {
       expect(kpi.countPartenaire, 0);
     });
 
-    test('utilise volume_15c si volume_corrige_15c est absent', () {
+    test('utilise volume_corrige_15c si volume_15c est absent (fallback legacy)', () {
       final rows = [
         {
           'volume_ambiant': 100,
-          'volume_15c': 95, // fallback sur volume_15c
+          'volume_15c': null,
+          'volume_corrige_15c': 95,
           'proprietaire_type': 'MONALUXE',
         },
       ];
@@ -133,6 +134,21 @@ void main() {
       final kpi = computeKpiReceptions(rows);
 
       expect(kpi.volume15c, 95.0);
+    });
+
+    test('priorise volume_15c lorsque volume_corrige_15c est aussi présent', () {
+      final rows = [
+        {
+          'volume_ambiant': 100,
+          'volume_15c': 100.0,
+          'volume_corrige_15c': 999.0,
+          'proprietaire_type': 'MONALUXE',
+        },
+      ];
+
+      final kpi = computeKpiReceptions(rows);
+
+      expect(kpi.volume15c, 100.0);
     });
   });
 }

--- a/test/features/kpi/kpi_sorties_compute_test.dart
+++ b/test/features/kpi/kpi_sorties_compute_test.dart
@@ -126,12 +126,12 @@ void main() {
       expect(kpi.volumeAmbient, 330);
     });
 
-    test('utilise volume_15c si volume_corrige_15c est absent', () {
+    test('utilise volume_corrige_15c si volume_15c est absent (fallback legacy)', () {
       final rows = [
         {
           'proprietaire_type': 'MONALUXE',
-          'volume_corrige_15c': null,
-          'volume_15c': 700,
+          'volume_15c': null,
+          'volume_corrige_15c': 700,
           'volume_ambiant': 720,
         },
       ];
@@ -143,6 +143,21 @@ void main() {
       expect(kpi.volumeAmbient, 720);
       expect(kpi.countMonaluxe, 1);
       expect(kpi.countPartenaire, 0);
+    });
+
+    test('priorise volume_15c lorsque volume_corrige_15c est aussi présent', () {
+      final rows = [
+        {
+          'proprietaire_type': 'MONALUXE',
+          'volume_15c': 100.0,
+          'volume_corrige_15c': 999.0,
+          'volume_ambiant': 110.0,
+        },
+      ];
+
+      final kpi = computeKpiSorties(rows);
+
+      expect(kpi.volume15c, 100.0);
     });
   });
 }

--- a/test/features/receptions/kpi/receptions_kpi_repository_test.dart
+++ b/test/features/receptions/kpi/receptions_kpi_repository_test.dart
@@ -19,7 +19,9 @@ void _testAggregationLogic(
 
   for (final row in mockData) {
     count += 1;
-    final v15 = (row['volume_corrige_15c'] as num?)?.toDouble() ?? 0.0;
+    final v15 = (row['volume_15c'] as num?)?.toDouble() ??
+        (row['volume_corrige_15c'] as num?)?.toDouble() ??
+        0.0;
     final vAmb = (row['volume_ambiant'] as num?)?.toDouble() ?? 0.0;
     volume15c += v15;
     volumeAmbient += vAmb;
@@ -61,6 +63,18 @@ void main() {
 
       // Act & Assert
       _testAggregationLogic(mockData, 2, 2000.0, 980.0);
+    });
+
+    test('agrégation - priorité volume_15c sur volume_corrige_15c', () {
+      final mockData = <Map<String, dynamic>>[
+        {
+          'volume_15c': 100.0,
+          'volume_corrige_15c': 999.0,
+          'volume_ambiant': 100.0,
+        },
+      ];
+
+      _testAggregationLogic(mockData, 1, 100.0, 100.0);
     });
 
     test('agrégation - format date correct (YYYY-MM-DD)', () {

--- a/test/features/sorties/kpi/sorties_kpi_repository_test.dart
+++ b/test/features/sorties/kpi/sorties_kpi_repository_test.dart
@@ -19,7 +19,9 @@ void _testAggregationLogic(
 
   for (final row in mockData) {
     count += 1;
-    final v15 = (row['volume_corrige_15c'] as num?)?.toDouble() ?? 0.0;
+    final v15 = (row['volume_15c'] as num?)?.toDouble() ??
+        (row['volume_corrige_15c'] as num?)?.toDouble() ??
+        0.0;
     final vAmb = (row['volume_ambiant'] as num?)?.toDouble() ?? 0.0;
     volume15c += v15;
     volumeAmbient += vAmb;
@@ -89,6 +91,18 @@ void main() {
 
       // Act & Assert
       _testAggregationLogic(mockData, 2, 2000.0, 980.0);
+    });
+
+    test('agrégation - priorité volume_15c sur volume_corrige_15c', () {
+      final mockData = <Map<String, dynamic>>[
+        {
+          'volume_15c': 100.0,
+          'volume_corrige_15c': 999.0,
+          'volume_ambiant': 100.0,
+        },
+      ];
+
+      _testAggregationLogic(mockData, 1, 100.0, 100.0);
     });
 
     test('agrégation - format date correct (TIMESTAMPTZ avec bornes)', () {


### PR DESCRIPTION
## Contexte
Migration progressive du système vers `volume_15c` comme colonne canonique @15°C, avec maintien de la compatibilité legacy `volume_corrige_15c`.

## Backend (STAGING + PROD)
- Ajout de `volume_15c` sur `sorties_produit`
- Adaptation des fonctions et triggers :
  - sorties_compute_15c_before_ins_lookup
  - sorties_before_validate_trg
  - sorties_after_insert_trg
  - validate_sortie
  - create_sortie
- Stratégie dual-write :
  volume_15c + volume_corrige_15c
- Aucune suppression legacy
- Aucune réécriture historique

## Flutter
- Lecture unifiée :
  volume_15c ?? volume_corrige_15c
- Mise à jour :
  - KPI providers
  - repositories
  - providers sorties
  - écrans ajustements stock
- Aucun changement sur les payloads d’écriture

## Validation
- STAGING : OK (sorties + stock + logs)
- PROD : OK (smoke test réel)
- Compensation test PROD effectuée :
  - stocks_adjustments
  - resynchronisation snapshot
- Données Monaluxe restaurées à l’identique

## Décisions d’architecture
- Source de vérité : v_stock_actuel
- stocks_snapshot = cache technique
- volume_15c = cible
- volume_corrige_15c = compatibilité transitoire

## Sécurité
- Aucun changement destructif
- Aucun DELETE/UPDATE massif
- Compatibilité backward totale

## Docs
- Migration summary
- Runbook
- Compatibility note

## Scope
Migration en mode compatibilité uniquement.
Aucune suppression du legacy dans cette PR.

## Next step
Phase 2 : décommission progressive de volume_corrige_15c