### PR TITLE
docs(cdr): align canonical pack with statut-only state model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Ce fichier documente les changements notables du projet **ML_PP MVP**, conformément aux bonnes pratiques de versionnage sémantique.
 
+## [2026-04-05] — CDR State Machine Cleanup
+
+### Changed
+- Removed legacy CdrEtat state machine
+- Removed applyTransition and canTransition
+- Removed cdr_logs_service
+- Removed writes to non-existent `etat` field
+
+### Fixed
+- Align CDR state handling with DB (`statut` only)
+- Prevent inconsistent dual state systems
+
+### Impact
+- Single source of truth: `statut`
+- Reduced technical debt
+- Safer CDR evolution going forward
+
 ## [Unreleased]
 
 ---

--- a/docs/CONTEXT/architecture_map.md
+++ b/docs/CONTEXT/architecture_map.md
@@ -90,20 +90,16 @@ PostgreSQL / Supabase :
 - Flux transport → cours_de_route
 - Audit → log_actions
 
-<<<<<<< HEAD
 Caches dérivés :
 - stocks_snapshot → technique uniquement, non source de vérité métier  
   (voir system_invariants.md)
-=======
-sorties_produit
 
-Calculs / persistance (runtime actuel, mode compatibilité) :
+**sorties_produit** — calculs / persistance (runtime actuel, mode compatibilité) :
 
 - **`volume_15c`** — colonne cible pour le volume à 15 °C  
 - **`volume_corrige_15c`** — conservée en parallèle (double write + compatibilité transitoire ; arrondi métier sorties documenté sur ce champ)
 
 **Lecture applicative (Flutter) :** règle officielle **`volume_15c ?? volume_corrige_15c`** sur les périmètres migrés.
->>>>>>> 9d68912 (snapshot: état stable avant restructuration repo (IA pack + gouvernance contexte))
 
 ---
 
@@ -113,6 +109,11 @@ Calculs / persistance (runtime actuel, mode compatibilité) :
 Toucher :
 - cours_de_route
 - écrans / providers CDR
+
+Attention:
+- le module CDR ne possède plus de machine d’état applicative
+- toute évolution doit se baser sur la colonne `statut` en base
+- ne pas introduire de logique parallèle (duplication hors `statut`, FSM, etc.)
 
 ## Si le besoin concerne Réception
 Toucher :

--- a/docs/CONTEXT/architecture_rules.md
+++ b/docs/CONTEXT/architecture_rules.md
@@ -117,6 +117,13 @@ Toute évolution doit suivre :
 
 ## RÈGLES FRONTEND
 
+Le frontend ne doit jamais implémenter une machine d’état métier parallèle à la base.
+
+Exemple interdit:
+- état local différent de `statut`
+- enum métier non aligné DB
+- logique de transition indépendante
+
 Le frontend n’est pas une source de vérité.
 
 Son rôle est de :

--- a/docs/CONTEXT/current_checkpoint.md
+++ b/docs/CONTEXT/current_checkpoint.md
@@ -44,6 +44,10 @@ Constats issus de `docs/DB/staging_status.md` et `docs/DB/prod_status.md` (inves
 
 # FIXES RÉCENTS CRITIQUES
 
+- Refactor CDR: suppression complète de la machine d’état applicative (`etat`, `CdrEtat`, `applyTransition`)
+- Alignement total avec la DB: `statut` devient la seule source de vérité
+- Suppression des écritures vers un champ non existant en base (`etat`)
+- Simplification du module CDR et réduction de dette technique
 - Fix alignement STAGING / PROD sur **`sorties_after_insert_trg()`**.
 - Correction du **débit stock @15 °C** en sortie (after-insert).
 - Harmonisation volumétrique sortie : **`COALESCE(NEW.volume_15c, NEW.volume_corrige_15c, 0)`** pour journal, snapshot et `log_actions.details.volume_15c`.
@@ -52,6 +56,7 @@ Constats issus de `docs/DB/staging_status.md` et `docs/DB/prod_status.md` (inves
 
 # ÉTAT ACTUEL ALIGNEMENT
 
+- Module CDR désormais aligné avec la DB (aucune divergence état/statut)
 - STAGING et PROD **alignés sur la logique critique** du débit sortie @15 °C dans **`sorties_after_insert_trg()`**.
 - **Aucun écart bloquant restant** sur ce pipeline stock (after-insert sortie) pour le volume @15 °C, sous réserve de vérification continue via `docs/DB/prod_status.md` / `docs/DB/staging_status.md`.
 - Autres écarts **non bloquants** possibles (doc, traçabilité migrations) : voir **ALIGNEMENT STAGING / PROD** ci-dessus.

--- a/docs/CONTEXT/project_context.md
+++ b/docs/CONTEXT/project_context.md
@@ -40,7 +40,7 @@ Chaque mouvement est journalisé et impacte les stocks.
 
 Représente un transport carburant entre un fournisseur et le dépôt.
 
-Statuts possibles :
+Workflow canonique :
 
 CHARGEMENT  
 TRANSIT  
@@ -48,10 +48,20 @@ FRONTIERE
 ARRIVE  
 DECHARGE
 
-Pipeline :
+Pipeline métier :
 
 ARRIVE → réception carburant  
 réception validée → CDR = DECHARGE
+
+Le CDR ne possède qu’une seule source de vérité d’état : la colonne `statut` en base de données.
+
+Toute logique applicative parallèle (ex: etat, state machine frontend) a été supprimée.
+
+Les transitions métier sont pilotées par:
+- les actions utilisateur (updateStatut)
+- les triggers DB (ex: réception → DECHARGE)
+
+Il est interdit d’introduire une seconde machine d’état côté application.
 
 ---
 

--- a/docs/CONTEXT/system_invariants.md
+++ b/docs/CONTEXT/system_invariants.md
@@ -117,6 +117,18 @@ CDR ARRIVE
 Interdit :
 - réception sur CDR déjà déchargé
 
+# 4.1 CDR STATE INVARIANT
+
+- Le CDR est piloté uniquement par la colonne `statut`
+- Les valeurs autorisées sont contrôlées en base (CHECK constraint)
+- Aucune machine d’état parallèle n’est autorisée côté application
+- Le passage à DECHARGE ne peut se faire que via une réception validée
+
+Interdit :
+- ajouter un champ etat
+- gérer un workflow parallèle côté frontend
+- bypass la règle réception → DECHARGE
+
 ---
 
 # 5. STOCK

--- a/docs/system_invariants.md
+++ b/docs/system_invariants.md
@@ -8,3 +8,19 @@
 - Toute valeur officielle @15°C provient de la DB uniquement
 - Toute estimation locale doit être explicitement marquée:
   "non canonique"
+
+---
+
+# 4. PIPELINE LOGISTIQUE
+
+# 4.1 CDR STATE INVARIANT
+
+- Le CDR est piloté uniquement par la colonne `statut`
+- Les valeurs autorisées sont contrôlées en base (CHECK constraint)
+- Aucune machine d’état parallèle n’est autorisée côté application
+- Le passage à DECHARGE ne peut se faire que via une réception validée
+
+Interdit :
+- ajouter un champ etat
+- gérer un workflow parallèle côté frontend
+- bypass la règle réception → DECHARGE


### PR DESCRIPTION
## Context
CDR module previously had a dual state system:
- DB: statut
- App: etat (state machine)

The etat system has been fully removed.

## Changes
- Document CDR as statut-driven only
- Add invariant: no parallel state machine allowed
- Update architecture rules (frontend must not duplicate state logic)
- Update current checkpoint (CDR cleanup)
- Update changelog

## Result
- Canonical pack aligned with real system
- Single source of truth: statut (DB)
- Safer future evolution of CDR module