### PR TITLE
feat(lot): workflow statut DB + alignement frontend + mise à jour pac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,82 @@
 
 Ce fichier documente les changements notables du projet **ML_PP MVP**, conformément aux bonnes pratiques de versionnage sémantique.
 
+## [2026-04-07] — Lot fournisseur : hardening DB + workflow statut
+
+### DB — Intégrité CDR ↔ lot
+
+- ajout trigger `trg_cours_de_route_enforce_fournisseur_lot`
+- ajout fonction `check_cdr_fournisseur_lot_liaison`
+- enforcement en base :
+  - cohérence fournisseur CDR ↔ lot
+  - cohérence produit CDR ↔ lot
+  - blocage rattachement selon statut CDR (ex: DECHARGE)
+  - interdiction modification si lot fermé
+
+→ la cohérence métier du lien CDR ↔ lot est désormais garantie par la DB
+
+### DB — Workflow statut lot fournisseur
+
+- ajout fonction `check_fournisseur_lot_statut_transition`
+- ajout trigger `trg_fournisseur_lot_statut_transition`
+- ajout contrainte `fournisseur_lot_statut_check`
+
+Règles :
+
+- statuts autorisés :
+  - `ouvert`
+  - `cloture`
+  - `facture`
+- transitions autorisées :
+  - ouvert → cloture
+  - cloture → facture
+- transitions interdites :
+  - retour arrière (ex: cloture → ouvert, facture → cloture)
+  - toute transition hors workflow
+- INSERT :
+  - statut obligatoire = `ouvert`
+
+→ le workflow métier du lot fournisseur est désormais porté par la DB
+
+### Frontend — Alignement workflow statut
+
+- ajout helper UI :
+  - `canCloseLot`
+  - `canMarkLotAsFactured`
+  - `isLotReadOnly`
+  - `lotStatutAllowsCdrLinkEdit`
+- ajout action :
+  - `markLotAsFactured`
+- adaptation écrans :
+  - `lot_detail_screen` :
+    - ouvert → clôture + ajout CDR
+    - cloture → facturation possible
+    - facture → lecture seule
+  - formulaire :
+    - pas de sélecteur de statut à la création ; lot créé en `ouvert` (texte d’aide UI)
+- mapping erreurs DB :
+  - `statut lot invalide`
+  - `transition de statut lot invalide`
+
+### Tests
+
+- ajout tests :
+  - workflow statut lot
+  - mapping erreurs
+  - providers lot
+  - écrans lot
+- 31 tests OK sur `test/features/lots/`
+
+### BREAKING
+
+- contraintes DB bloquantes :
+  - transitions statut invalides refusées
+  - incohérences CDR ↔ lot bloquées
+
+→ impact direct API / frontend en cas de violation
+
+---
+
 ## [2026-04-07] — Stabilisation module lot fournisseur (CDR ↔ lot)
 
 ### Backend (DB)

--- a/docs/CONTEXT/current_checkpoint.md
+++ b/docs/CONTEXT/current_checkpoint.md
@@ -25,7 +25,15 @@ Point d’entrée principal pour comprendre l’état actuel du système et agir
 - **DB tests STAGING** du pipeline critique exécutés avec succès (voir **VALIDATION STAGING RÉCENTE**)
 - Schéma **ASTM** accessible côté STAGING ; **RLS**, **stock**, **réception**, **sortie** validés sur ce périmètre en STAGING
 - Pack canonique et **invariants VOL15** synchronisés (`docs/system_invariants.md`, `docs/CONTEXT/system_invariants.md`)
-- **Lot fournisseur** introduit et **opérationnel** (STAGING + PROD) : table `public.fournisseur_lot`, colonne nullable `public.cours_de_route.fournisseur_lot_id` ; module app minimal (création lot, liste `/cours/lots`, `/cours/lots/new`, lien dans formulaire / détail CDR, colonne **Réf. lot** en liste desktop). UX liste CDR : **Nouveau camion**, **Lot fournisseur**, colonne **Dépôt** retirée du tableau desktop — **sans** changement du pilotage **`statut`** CDR en DB.
+- **Lot fournisseur** introduit et **industrialisé** (STAGING + PROD) :
+  - table `public.fournisseur_lot`
+  - relation optionnelle `cours_de_route.fournisseur_lot_id`
+  - **intégrité CDR ↔ lot garantie par la DB** (trigger)
+  - **workflow statut lot porté par la DB** :
+    - `ouvert → cloture → facture`
+    - transitions invalides bloquées
+  - module frontend aligné (UI pilotée par DB)
+  - couverture app : création lot, liste `/cours/lots`, `/cours/lots/new`, lien formulaire / détail CDR, colonne **Réf. lot** desktop ; liste CDR : **Nouveau camion**, **Lot fournisseur**, **Dépôt** retiré du tableau desktop — **sans** changement du pilotage **`statut`** CDR en DB.
 
 ---
 
@@ -52,6 +60,15 @@ Constats issus de `docs/DB/staging_status.md` et `docs/DB/prod_status.md` (inves
 - Fix alignement STAGING / PROD sur **`sorties_after_insert_trg()`**.
 - Correction du **débit stock @15 °C** en sortie (after-insert).
 - Harmonisation volumétrique sortie : **`COALESCE(NEW.volume_15c, NEW.volume_corrige_15c, 0)`** pour journal, snapshot et `log_actions.details.volume_15c`.
+- Hardening DB du module lot fournisseur :
+  - trigger `trg_cours_de_route_enforce_fournisseur_lot`
+  - validation cohérence fournisseur / produit / statut
+  - blocage des rattachements invalides CDR ↔ lot
+- Implémentation du workflow statut lot en DB :
+  - fonction `check_fournisseur_lot_statut_transition`
+  - trigger `trg_fournisseur_lot_statut_transition`
+  - contrainte CHECK sur les statuts
+  - transitions strictement contrôlées
 
 ---
 
@@ -61,6 +78,11 @@ Constats issus de `docs/DB/staging_status.md` et `docs/DB/prod_status.md` (inves
 - STAGING et PROD **alignés sur la logique critique** du débit sortie @15 °C dans **`sorties_after_insert_trg()`**.
 - **Aucun écart bloquant restant** sur ce pipeline stock (after-insert sortie) pour le volume @15 °C, sous réserve de vérification continue via `docs/DB/prod_status.md` / `docs/DB/staging_status.md`.
 - Autres écarts **non bloquants** possibles (doc, traçabilité migrations) : voir **ALIGNEMENT STAGING / PROD** ci-dessus.
+- Module lot fournisseur :
+  - STAGING et PROD alignés sur :
+    - intégrité CDR ↔ lot
+    - workflow statut lot
+  - aucune divergence connue sur ce périmètre
 
 ---
 
@@ -81,6 +103,10 @@ Constats issus des **DB tests** et vérifications manuelles sur **STAGING** (pas
 - Stabilisation post-validation STAGING (pipeline critique app + DB + RLS)
 - Gouvernance du pack canonique maintenue
 - Enrichissement **CDR** par structuration amont **lot fournisseur** (relation optionnelle, vérité toujours `statut` + réception pour le stock)
+- Stabilisation du module lot fournisseur (intégrité + workflow DB)
+- Préparation des évolutions :
+  - audit des transitions lot
+  - observabilité métier
 - Pistes prioritaires : observabilité stock, audit automatique DB / staging–prod, hardening tests / monitoring
 
 ---
@@ -92,6 +118,8 @@ Constats issus des **DB tests** et vérifications manuelles sur **STAGING** (pas
 - Moteur ASTM
 - Triggers, fonctions et vues critiques
 - **Pipeline VOL15 côté frontend** (contrat de lecture, services DB-first sur le périmètre traité) — considéré stable ; **ne pas refactorer sans besoin réel**
+- Module lot fournisseur (intégrité DB + workflow statut) considéré comme stable
+- Toute modification doit passer par migration et validation staging
 
 ---
 

--- a/docs/db/prod_status.md
+++ b/docs/db/prod_status.md
@@ -35,6 +35,22 @@ Donner l’état actuel de la base de production et sécuriser toute interventio
 
 → la cohérence métier du lien CDR ↔ lot est désormais garantie par la DB
 
+**Workflow statut lot** :
+
+- trigger : `trg_fournisseur_lot_statut_transition`
+- fonction : `check_fournisseur_lot_statut_transition`
+- CHECK : `fournisseur_lot_statut_check`
+
+**Règles appliquées** :
+
+- INSERT uniquement en `ouvert`
+- `ouvert` → `cloture`
+- `cloture` → `facture`
+- retours arrière interdits
+- statuts invalides interdits
+
+→ le cycle de vie du lot est désormais garanti par la DB
+
 **`public.v_stock_actuel`** : exécutable ; lit `v_stocks_snapshot_corrige`. Colonnes : `depot_id`, `citerne_id`, `produit_id`, `proprietaire_type`, `stock_ambiant`, `stock_15c`, `last_movement_at`, `updated_at`, `stock_ambiant_base`, `stock_15c_base`, `delta_ambiant_total`, `delta_15c_total`. Au moins une ligne avec `delta_ambiant_total = 10` et `delta_15c_total = 10`.
 
 **Triggers `receptions`** : `receptions_after_ins` → `reception_after_ins_trg()` ; `trg_00_receptions_block_update_delete` ; `trg_receptions_check_cdr_arrive` ; `trg_receptions_check_produit_citerne` ; `trg_receptions_compute_15c_before_ins` ; `trg_receptions_log_created` ; `trg_receptions_set_created_by` ; `trg_receptions_set_volume_ambiant`.
@@ -63,6 +79,10 @@ Donner l’état actuel de la base de production et sécuriser toute interventio
 
 ## DERNIÈRE INTERVENTION
 
+- **2026-04-07** — workflow DB du statut lot fournisseur :
+  - ajout trigger + fonction de validation
+  - ajout CHECK constraint sur `statut`
+  - sécurisation du cycle `ouvert → cloture → facture`
 - **2026-04-07** — hardening DB du module lot fournisseur :
   - ajout trigger + fonction de validation
   - sécurisation du rattachement CDR ↔ lot
@@ -80,6 +100,10 @@ Donner l’état actuel de la base de production et sécuriser toute interventio
   - logique métier portée par trigger DB
   - modification directe de `fournisseur_lot_id` soumise à contraintes strictes
   - erreurs bloquantes possibles côté API si incohérence
+- **Lot fournisseur (workflow statut)** :
+  - statut porté par trigger DB + CHECK constraint
+  - toute mise à jour directe de `statut` hors transitions autorisées échoue
+  - erreurs bloquantes possibles côté API si transition invalide
 - Désalignement documentaire partiel (doc vs triggers réellement branchés).  
 - Ajustement stock réel présent (`stocks_adjustments`).  
 - Conventions de logs / couches legacy coexistantes.  
@@ -158,6 +182,21 @@ FROM information_schema.columns
 WHERE table_schema = 'public'
   AND table_name = 'cours_de_route'
   AND column_name = 'fournisseur_lot_id';
+```
+
+### Lot fournisseur — workflow statut
+
+```sql
+SELECT tgname
+FROM pg_trigger
+WHERE tgname = 'trg_fournisseur_lot_statut_transition';
+```
+
+```sql
+SELECT conname, pg_get_constraintdef(oid)
+FROM pg_constraint
+WHERE conrelid = 'public.fournisseur_lot'::regclass
+  AND conname = 'fournisseur_lot_statut_check';
 ```
 
 ### Référence complémentaire

--- a/docs/db/staging_status.md
+++ b/docs/db/staging_status.md
@@ -27,6 +27,19 @@ Donner l’état actuel de la base staging et permettre une vérification rapide
 
 ## DERNIÈRES MODIFICATIONS
 
+- **2026-04-07** — **Lot fournisseur (workflow statut DB)** :
+  - ajout du trigger `trg_fournisseur_lot_statut_transition`
+  - ajout de la fonction `check_fournisseur_lot_statut_transition`
+  - transition de statuts sécurisée en base :
+    - `ouvert` → `cloture`
+    - `cloture` → `facture`
+  - transitions interdites :
+    - `cloture` → `ouvert`
+    - `facture` → `cloture`
+    - `facture` → `ouvert`
+  - INSERT autorisé uniquement avec `statut = 'ouvert'`
+  - ajout du CHECK `fournisseur_lot_statut_check`
+  - validation STAGING OK
 - **2026-04-07** — **Lot fournisseur (hardening DB)** :
   - ajout du trigger `trg_cours_de_route_enforce_fournisseur_lot`
   - fonction `check_cdr_fournisseur_lot_liaison`
@@ -61,6 +74,11 @@ Donner l’état actuel de la base staging et permettre une vérification rapide
 - **Lot fournisseur (nouveau périmètre DB)** :
   - contraintes métier désormais portées par trigger
   - toute modification du champ `cours_de_route.fournisseur_lot_id` doit être testée
+  - erreurs levées via `RAISE EXCEPTION` → impact direct API / frontend
+- **Lot fournisseur (workflow statut)** :
+  - le cycle de vie du lot est désormais porté par trigger DB
+  - toute modification directe de `public.fournisseur_lot.statut` est soumise à contraintes
+  - les transitions arrière sont interdites
   - erreurs levées via `RAISE EXCEPTION` → impact direct API / frontend
 
 ---
@@ -134,6 +152,21 @@ FROM information_schema.columns
 WHERE table_schema = 'public'
   AND table_name = 'cours_de_route'
   AND column_name = 'fournisseur_lot_id';
+```
+
+### Lot fournisseur — workflow statut
+
+```sql
+SELECT tgname
+FROM pg_trigger
+WHERE tgname = 'trg_fournisseur_lot_statut_transition';
+```
+
+```sql
+SELECT conname, pg_get_constraintdef(oid)
+FROM pg_constraint
+WHERE conrelid = 'public.fournisseur_lot'::regclass
+  AND conname = 'fournisseur_lot_statut_check';
 ```
 
 ### Référence complémentaire

--- a/lib/features/lots/data/fournisseur_lot_service.dart
+++ b/lib/features/lots/data/fournisseur_lot_service.dart
@@ -154,6 +154,23 @@ produits(nom, code)
     return FournisseurLot.fromMap(row);
   }
 
+  /// Passe le lot en statut « facturé » (champ `statut` uniquement).
+  Future<FournisseurLot> markLotAsFactured(String lotId) async {
+    final trimmed = lotId.trim();
+    if (trimmed.isEmpty) {
+      throw ArgumentError('L\'id du lot est requis pour markLotAsFactured().');
+    }
+
+    final row = await _client
+        .from(_table)
+        .update({'statut': StatutFournisseurLot.facture.db})
+        .eq('id', trimmed)
+        .select(_selectWithRefs)
+        .single();
+
+    return FournisseurLot.fromMap(row);
+  }
+
   Future<void> delete(String id) async {
     await _client.from(_table).delete().eq('id', id);
   }

--- a/lib/features/lots/lot_statut_ui.dart
+++ b/lib/features/lots/lot_statut_ui.dart
@@ -1,0 +1,20 @@
+// 📌 Module : Lots — Visibilité des actions selon le statut (présentation uniquement).
+// 🧭 La DB impose le workflow ; ces helpers ne font que refléter l’UI attendue.
+
+import 'package:ml_pp_mvp/features/lots/models/fournisseur_lot.dart';
+
+/// Propose le bouton « Clôturer le lot » (statut `ouvert` uniquement).
+bool canCloseLot(StatutFournisseurLot statut) =>
+    statut == StatutFournisseurLot.ouvert;
+
+/// Propose le bouton « Marquer comme facturé » (statut `cloture` uniquement).
+bool canMarkLotAsFactured(StatutFournisseurLot statut) =>
+    statut == StatutFournisseurLot.cloture;
+
+/// Rattachement / détachement CDR autorisés en UI seulement pour un lot ouvert.
+bool lotStatutAllowsCdrLinkEdit(StatutFournisseurLot statut) =>
+    statut == StatutFournisseurLot.ouvert;
+
+/// Lot facturé : plus aucune action de transition ni de lien CDR côté UI.
+bool isLotReadOnly(StatutFournisseurLot statut) =>
+    statut == StatutFournisseurLot.facture;

--- a/lib/features/lots/lot_user_message_from_error.dart
+++ b/lib/features/lots/lot_user_message_from_error.dart
@@ -1,4 +1,4 @@
-// 📌 Module : Lots — Message utilisateur à partir d’une erreur backend (liaison CDR ↔ lot).
+// 📌 Module : Lots — Message utilisateur à partir d’une erreur backend (CDR ↔ lot, statut lot).
 // 🧭 Présentation uniquement ; la base reste la source de vérité.
 
 import 'package:flutter/foundation.dart';
@@ -41,6 +41,14 @@ String extractLotBackendErrorText(Object error) {
 String mapLotUserMessage(Object error) {
   final raw = extractLotBackendErrorText(error);
   final n = normalizeLotBackendErrorText(raw);
+
+  if (n.contains('transition de statut lot invalide')) {
+    return "Cette action n'est pas autorisée pour le statut actuel du lot.";
+  }
+
+  if (n.contains('statut lot invalide')) {
+    return 'Le statut du lot est invalide.';
+  }
 
   if (n.contains(
         'impossible de rattacher : le fournisseur du cdr ne correspond pas',

--- a/lib/features/lots/providers/fournisseur_lot_providers.dart
+++ b/lib/features/lots/providers/fournisseur_lot_providers.dart
@@ -185,8 +185,8 @@ void invalidateAfterLotCdrLinkChange(
   ref.invalidate(fournisseurLotByIdProvider(lot.id));
 }
 
-/// Après clôture (statut uniquement) : listes, détail, compteurs.
-void invalidateAfterLotClose(riverpod.WidgetRef ref, FournisseurLot lot) {
+void _invalidateLotAfterStatutChange(
+    riverpod.WidgetRef ref, FournisseurLot lot) {
   ref.invalidate(fournisseurLotsProvider);
   ref.invalidate(lotDetailProvider(lot.id));
   ref.invalidate(fournisseurLotByIdProvider(lot.id));
@@ -203,4 +203,14 @@ void invalidateAfterLotClose(riverpod.WidgetRef ref, FournisseurLot lot) {
     fournisseurLotsOuvertsByFournisseurProvider(lot.fournisseurId),
   );
   ref.invalidate(fournisseurLotCountsByStatutProvider);
+}
+
+/// Après clôture (statut uniquement) : listes, détail, compteurs.
+void invalidateAfterLotClose(riverpod.WidgetRef ref, FournisseurLot lot) {
+  _invalidateLotAfterStatutChange(ref, lot);
+}
+
+/// Après facturation (statut uniquement) : mêmes invalidations que la clôture.
+void invalidateAfterLotFactured(riverpod.WidgetRef ref, FournisseurLot lot) {
+  _invalidateLotAfterStatutChange(ref, lot);
 }

--- a/lib/features/lots/screens/fournisseur_lot_form_screen.dart
+++ b/lib/features/lots/screens/fournisseur_lot_form_screen.dart
@@ -120,6 +120,15 @@ class _FournisseurLotFormScreenState
                   color: Theme.of(context).primaryColor,
                 ),
           ),
+          const SizedBox(height: 8),
+          Text(
+            key: const Key('lot_form_statut_ouvert_hint'),
+            'Nouveau lot : statut Ouvert (imposé). La clôture et la '
+            'facturation se font depuis le détail du lot.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
           const SizedBox(height: 16),
           DropdownButtonFormField<String>(
             initialValue: selectedFournisseurId,

--- a/lib/features/lots/screens/lot_detail_screen.dart
+++ b/lib/features/lots/screens/lot_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:ml_pp_mvp/core/models/user_role.dart';
 import 'package:ml_pp_mvp/features/cours_route/models/cours_de_route.dart';
 import 'package:ml_pp_mvp/features/lots/models/fournisseur_lot.dart';
 import 'package:ml_pp_mvp/features/lots/models/lot_detail_view.dart';
+import 'package:ml_pp_mvp/features/lots/lot_statut_ui.dart';
 import 'package:ml_pp_mvp/features/lots/lot_user_message_from_error.dart';
 import 'package:ml_pp_mvp/features/lots/providers/fournisseur_lot_providers.dart';
 import 'package:ml_pp_mvp/features/profil/providers/profil_provider.dart';
@@ -67,6 +68,50 @@ class LotDetailScreen extends ConsumerWidget {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Lot clôturé')),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(mapLotUserMessage(e))),
+        );
+      }
+    }
+  }
+
+  Future<void> _onMarkLotAsFacturedPressed(
+    BuildContext context,
+    WidgetRef ref,
+    FournisseurLot lot,
+  ) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Marquer ce lot comme facturé ?'),
+        content: const Text(
+          'Cette action est définitive. Le lot passera en lecture seule.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Annuler'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Marquer comme facturé'),
+          ),
+        ],
+      ),
+    );
+
+    if (ok != true || !context.mounted) return;
+
+    try {
+      await ref.read(fournisseurLotServiceProvider).markLotAsFactured(lot.id);
+      invalidateAfterLotFactured(ref, lot);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Lot marqué comme facturé')),
         );
       }
     } catch (e) {
@@ -376,7 +421,7 @@ class LotDetailScreen extends ConsumerWidget {
             data: (refData) {
               final lot = view.lot;
               final lotEditable =
-                  canWrite && lot.statut == StatutFournisseurLot.ouvert;
+                  canWrite && lotStatutAllowsCdrLinkEdit(lot.statut);
               final fournisseurLabel =
                   resolveName(refData, lot.fournisseurId, 'fournisseur');
               final produitLabel =
@@ -426,12 +471,28 @@ class LotDetailScreen extends ConsumerWidget {
                     ],
                   ),
                   if (canWrite &&
-                      lot.statut != StatutFournisseurLot.ouvert) ...[
+                      lot.statut == StatutFournisseurLot.cloture) ...[
                     Padding(
                       padding: const EdgeInsets.only(bottom: 12),
                       child: Text(
-                        'Lot clôturé : aucune modification n’est disponible.',
+                        'Lot clôturé : plus de rattachement ni détachement de '
+                        'cours. Vous pouvez marquer le lot comme facturé.',
                         key: const Key('lot_detail_closed_notice'),
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurfaceVariant,
+                            ),
+                      ),
+                    ),
+                  ],
+                  if (canWrite &&
+                      lot.statut == StatutFournisseurLot.facture) ...[
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: Text(
+                        'Lot facturé : lecture seule.',
+                        key: const Key('lot_detail_facture_readonly_notice'),
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                               color: Theme.of(context)
                                   .colorScheme
@@ -569,7 +630,7 @@ class LotDetailScreen extends ConsumerWidget {
                       ),
                     ),
                   const SizedBox(height: 24),
-                  if (lotEditable) ...[
+                  if (canWrite && canCloseLot(lot.statut)) ...[
                     OutlinedButton.icon(
                       key: const Key('lot_detail_close_lot_button'),
                       onPressed: () =>
@@ -578,12 +639,26 @@ class LotDetailScreen extends ConsumerWidget {
                       label: const Text('Clôturer le lot'),
                     ),
                     const SizedBox(height: 8),
+                  ],
+                  if (canWrite && canMarkLotAsFactured(lot.statut)) ...[
+                    FilledButton.icon(
+                      key: const Key('lot_detail_mark_factured_button'),
+                      onPressed: () => _onMarkLotAsFacturedPressed(
+                        context,
+                        ref,
+                        lot,
+                      ),
+                      icon: const Icon(Icons.receipt_long_outlined),
+                      label: const Text('Marquer comme facturé'),
+                    ),
+                    const SizedBox(height: 8),
+                  ],
+                  if (lotEditable)
                     FilledButton.icon(
                       onPressed: () => _showAddCdrSheet(context, ref, lot),
                       icon: const Icon(Icons.add),
                       label: const Text('Ajouter CDR au lot'),
                     ),
-                  ],
                   ],
                 ),
               );

--- a/supabase/migrations/20260407120000_fournisseur_lot_statut_workflow.sql
+++ b/supabase/migrations/20260407120000_fournisseur_lot_statut_workflow.sql
@@ -1,0 +1,123 @@
+-- ============================================================================
+-- Lot fournisseur — workflow de statut (source de vérité DB)
+-- ============================================================================
+-- Table : public.fournisseur_lot, colonne statut (texte).
+--
+-- Transitions autorisées :
+--   ouvert → cloture
+--   cloture → facture
+-- INSERT : statut doit être strictement 'ouvert'.
+-- Ne modifie pas cours_de_route, stock ni volumétrie.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.check_fournisseur_lot_statut_transition(
+  p_old_statut text,
+  p_new_statut text
+) RETURNS void
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF p_old_statut IS NOT DISTINCT FROM p_new_statut THEN
+    RETURN;
+  END IF;
+
+  IF p_new_statut IS NULL OR p_new_statut NOT IN ('ouvert', 'cloture', 'facture') THEN
+    RAISE EXCEPTION 'Statut lot invalide : %', p_new_statut;
+  END IF;
+
+  IF p_old_statut IS NULL OR p_old_statut NOT IN ('ouvert', 'cloture', 'facture') THEN
+    RAISE EXCEPTION 'Statut lot invalide : %', p_old_statut;
+  END IF;
+
+  IF p_old_statut = 'ouvert' AND p_new_statut = 'cloture' THEN
+    RETURN;
+  END IF;
+
+  IF p_old_statut = 'cloture' AND p_new_statut = 'facture' THEN
+    RETURN;
+  END IF;
+
+  RAISE EXCEPTION
+    'Transition de statut lot invalide : % → %',
+    p_old_statut,
+    p_new_statut;
+END;
+$$;
+
+COMMENT ON FUNCTION public.check_fournisseur_lot_statut_transition(text, text) IS
+'Valide les changements de statut fournisseur_lot : ouvert→cloture, cloture→facture uniquement.';
+
+
+CREATE OR REPLACE FUNCTION public.trg_fournisseur_lot_statut_transition()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.statut IS NULL OR NEW.statut IS DISTINCT FROM 'ouvert' THEN
+      RAISE EXCEPTION 'Statut lot invalide : %', NEW.statut;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.statut IS DISTINCT FROM NEW.statut THEN
+      PERFORM public.check_fournisseur_lot_statut_transition(OLD.statut, NEW.statut);
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_fournisseur_lot_statut_transition ON public.fournisseur_lot;
+
+CREATE TRIGGER trg_fournisseur_lot_statut_transition
+  BEFORE INSERT OR UPDATE
+  ON public.fournisseur_lot
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trg_fournisseur_lot_statut_transition();
+
+COMMENT ON TRIGGER trg_fournisseur_lot_statut_transition ON public.fournisseur_lot IS
+'INSERT : statut = ouvert uniquement. UPDATE : transitions ouvert→cloture→facture, pas de retour arrière.';
+
+
+-- Contrainte CHECK : alignée sur l''enum métier Flutter / JSON (ouvert | cloture | facture).
+-- Échoue si des lignes hors périmètre existent : corriger les données avant d''appliquer la migration.
+ALTER TABLE public.fournisseur_lot
+  DROP CONSTRAINT IF EXISTS fournisseur_lot_statut_check;
+
+ALTER TABLE public.fournisseur_lot
+  ADD CONSTRAINT fournisseur_lot_statut_check
+  CHECK (statut IN ('ouvert', 'cloture', 'facture'));
+
+COMMENT ON CONSTRAINT fournisseur_lot_statut_check ON public.fournisseur_lot IS
+'Statut lot autorisé : ouvert, cloture, facture (workflow géré par trigger).';
+
+-- ---------------------------------------------------------------------------
+-- Tests manuels (psql / staging) — adapter les UUID
+-- ---------------------------------------------------------------------------
+-- -- 1) INSERT avec statut ≠ ouvert → FAIL
+-- INSERT INTO public.fournisseur_lot (fournisseur_id, produit_id, reference, statut)
+-- VALUES (:fid, :pid, 'TEST-WF-1', 'cloture');
+--
+-- -- 2) ouvert → cloture → OK
+-- INSERT INTO public.fournisseur_lot (fournisseur_id, produit_id, reference, statut)
+-- VALUES (:fid, :pid, 'TEST-WF-2', 'ouvert')
+-- RETURNING id \gset
+-- UPDATE public.fournisseur_lot SET statut = 'cloture' WHERE id = :'id';
+--
+-- -- 3) cloture → ouvert → FAIL (ligne encore en cloture)
+-- UPDATE public.fournisseur_lot SET statut = 'ouvert' WHERE id = :'id';
+--
+-- -- 4) cloture → facture → OK
+-- UPDATE public.fournisseur_lot SET statut = 'facture' WHERE id = :'id';
+--
+-- -- 5) facture → cloture → FAIL
+-- UPDATE public.fournisseur_lot SET statut = 'cloture' WHERE id = :'id';
+--
+-- -- 6) statut inconnu → FAIL (CHECK + trigger)
+-- UPDATE public.fournisseur_lot SET statut = 'archive' WHERE id = :'id';

--- a/test/features/lots/fake_fournisseur_lot_service.dart
+++ b/test/features/lots/fake_fournisseur_lot_service.dart
@@ -17,6 +17,7 @@ class FakeFournisseurLotService implements FournisseurLotService {
   final List<(String cdrId, String lotId)> attachCalls = [];
   final List<String> detachCalls = [];
   final List<String> closeLotCalls = [];
+  final List<String> markLotAsFacturedCalls = [];
 
   @override
   Future<List<FournisseurLot>> getAll() async => throw UnimplementedError();
@@ -98,6 +99,17 @@ class FakeFournisseurLotService implements FournisseurLotService {
       throw StateError('closeLot: lot introuvable');
     }
     lotOverride = l.copyWith(statut: StatutFournisseurLot.cloture);
+    return lotOverride!;
+  }
+
+  @override
+  Future<FournisseurLot> markLotAsFactured(String lotId) async {
+    markLotAsFacturedCalls.add(lotId);
+    final l = lotOverride;
+    if (l == null || l.id != lotId) {
+      throw StateError('markLotAsFactured: lot introuvable');
+    }
+    lotOverride = l.copyWith(statut: StatutFournisseurLot.facture);
     return lotOverride!;
   }
 }

--- a/test/features/lots/lot_statut_ui_test.dart
+++ b/test/features/lots/lot_statut_ui_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ml_pp_mvp/features/lots/lot_statut_ui.dart';
+import 'package:ml_pp_mvp/features/lots/models/fournisseur_lot.dart';
+
+void main() {
+  test('canCloseLot / canMarkLotAsFactured / CDR edit / readOnly', () {
+    expect(canCloseLot(StatutFournisseurLot.ouvert), true);
+    expect(canCloseLot(StatutFournisseurLot.cloture), false);
+    expect(canMarkLotAsFactured(StatutFournisseurLot.cloture), true);
+    expect(canMarkLotAsFactured(StatutFournisseurLot.ouvert), false);
+    expect(lotStatutAllowsCdrLinkEdit(StatutFournisseurLot.ouvert), true);
+    expect(lotStatutAllowsCdrLinkEdit(StatutFournisseurLot.cloture), false);
+    expect(isLotReadOnly(StatutFournisseurLot.facture), true);
+    expect(isLotReadOnly(StatutFournisseurLot.cloture), false);
+  });
+}

--- a/test/features/lots/lot_user_message_from_error_test.dart
+++ b/test/features/lots/lot_user_message_from_error_test.dart
@@ -70,6 +70,22 @@ void main() {
       );
     });
 
+    test('transition de statut lot invalide', () {
+      expect(
+        mapLotUserMessage(
+          Exception('Transition de statut lot invalide : cloture → ouvert'),
+        ),
+        "Cette action n'est pas autorisée pour le statut actuel du lot.",
+      );
+    });
+
+    test('statut lot invalide', () {
+      expect(
+        mapLotUserMessage(Exception('Statut lot invalide : archive')),
+        'Le statut du lot est invalide.',
+      );
+    });
+
     test('erreur inconnue → fallback', () {
       expect(
         mapLotUserMessage(Exception('constraint xyz violated')),

--- a/test/features/lots/screens/fournisseur_lot_form_screen_test.dart
+++ b/test/features/lots/screens/fournisseur_lot_form_screen_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ml_pp_mvp/features/lots/screens/fournisseur_lot_form_screen.dart';
+import 'package:ml_pp_mvp/shared/providers/ref_data_provider.dart';
+
+RefDataCache _minimalRefData() => RefDataCache(
+      fournisseurs: const {'f1': 'F1'},
+      produits: const {'p1': 'P1'},
+      produitCodes: const {},
+      depots: const {},
+      loadedAt: DateTime.now(),
+    );
+
+void main() {
+  testWidgets('création : hint statut Ouvert, pas de champ statut', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          refDataProvider.overrideWith((ref) async => _minimalRefData()),
+        ],
+        child: const MaterialApp(
+          home: FournisseurLotFormScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('lot_form_statut_ouvert_hint')), findsOneWidget);
+    expect(find.text('Statut'), findsNothing);
+  });
+}

--- a/test/features/lots/screens/lot_detail_screen_test.dart
+++ b/test/features/lots/screens/lot_detail_screen_test.dart
@@ -130,6 +130,10 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('lot_detail_close_lot_button')), findsOneWidget);
+    expect(
+      find.byKey(const Key('lot_detail_mark_factured_button')),
+      findsNothing,
+    );
   });
 
   testWidgets('clôture confirmée : service, refresh, SnackBar', (
@@ -211,9 +215,103 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('lot_detail_close_lot_button')), findsNothing);
+    expect(
+      find.byKey(const Key('lot_detail_mark_factured_button')),
+      findsOneWidget,
+    );
     expect(find.text('Ajouter CDR au lot'), findsNothing);
     expect(find.text('Détacher'), findsNothing);
     expect(find.byKey(const Key('lot_detail_closed_notice')), findsOneWidget);
     expect(find.text('ZZ-000-ZZ'), findsOneWidget);
+  });
+
+  testWidgets('lot facturé : aucune transition ni édition CDR', (tester) async {
+    final lot = FournisseurLot.empty().copyWith(
+      id: 'lot-1',
+      fournisseurId: 'f1',
+      produitId: 'p1',
+      reference: 'REF-F',
+      statut: StatutFournisseurLot.facture,
+    );
+    final cdr = CoursDeRoute.empty().copyWith(
+      id: 'cdr-1',
+      fournisseurId: 'f1',
+      produitId: 'p1',
+      depotDestinationId: 'd1',
+      plaqueCamion: 'FA-111-AA',
+    );
+    final fake = FakeFournisseurLotService(
+      lotOverride: lot,
+      cdrsForLot: [cdr],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          fournisseurLotServiceProvider.overrideWithValue(fake),
+          lotDetailProviderOverride(fake),
+          userRoleProvider.overrideWith((ref) => UserRole.admin),
+          refDataProvider.overrideWith((ref) async => _emptyRefData()),
+        ],
+        child: const MaterialApp(
+          home: LotDetailScreen(lotId: 'lot-1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('lot_detail_close_lot_button')), findsNothing);
+    expect(
+      find.byKey(const Key('lot_detail_mark_factured_button')),
+      findsNothing,
+    );
+    expect(find.text('Ajouter CDR au lot'), findsNothing);
+    expect(find.text('Détacher'), findsNothing);
+    expect(
+      find.byKey(const Key('lot_detail_facture_readonly_notice')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('facturation confirmée : service + refresh', (tester) async {
+    final lot = FournisseurLot.empty().copyWith(
+      id: 'lot-1',
+      fournisseurId: 'f1',
+      produitId: 'p1',
+      reference: 'REF-FAC',
+      statut: StatutFournisseurLot.cloture,
+    );
+    final fake = FakeFournisseurLotService(lotOverride: lot);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          fournisseurLotServiceProvider.overrideWithValue(fake),
+          lotDetailProviderOverride(fake),
+          userRoleProvider.overrideWith((ref) => UserRole.admin),
+          refDataProvider.overrideWith((ref) async => _emptyRefData()),
+        ],
+        child: const MaterialApp(
+          home: LotDetailScreen(lotId: 'lot-1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final btn = find.byKey(const Key('lot_detail_mark_factured_button'));
+    await tester.ensureVisible(btn);
+    await tester.pumpAndSettle();
+    await tester.tap(btn);
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.text('Marquer comme facturé'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(fake.markLotAsFacturedCalls, ['lot-1']);
+    expect(fake.lotOverride!.statut, StatutFournisseurLot.facture);
+    expect(find.text('Lot marqué comme facturé'), findsOneWidget);
+    expect(btn, findsNothing);
   });
 }


### PR DESCRIPTION
# 🎯 Contexte

Formalisation du workflow de statut du module **lot fournisseur** et alignement complet frontend + documentation.

---

# 🔧 Backend (DB)

* ajout migration `20260407120000_fournisseur_lot_statut_workflow.sql`
* ajout fonction `check_fournisseur_lot_statut_transition`
* ajout trigger `trg_fournisseur_lot_statut_transition`
* ajout contrainte `fournisseur_lot_statut_check`

Workflow sécurisé en DB :

* `ouvert → cloture`
* `cloture → facture`

Blocages :

* transitions arrière interdites
* statut invalide interdit
* INSERT autorisé uniquement en `ouvert`

---

# 💻 Frontend

* ajout helper `lot_statut_ui.dart`
* ajout action `markLotAsFactured`
* adaptation UI du détail lot selon statut :

  * `ouvert` → clôture + gestion CDR
  * `cloture` → facturation possible
  * `facture` → lecture seule
* création lot forcée implicitement en `ouvert`
* mapping des erreurs DB statut lot → messages utilisateur

---

# 🧪 Tests

* tests helpers statut lot
* tests écrans lot
* tests formulaire lot
* tests mapping erreurs

---

# 📚 Documentation

* update `docs/DB/staging_status.md`
* update `docs/DB/prod_status.md`
* update `docs/CONTEXT/current_checkpoint.md`
* update `CHANGELOG.md`

---

# ⚠️ Breaking changes

* transitions de statut lot désormais strictement contrôlées en base
* toute mise à jour directe incohérente du statut échoue côté API / DB

---

# ✅ Validation

* STAGING validé
* PROD aligné
* tests module lots OK
